### PR TITLE
chore: change VisionOS to visionOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
   Build spatial apps with React.
 </p>
 
-React Native Vision OS allows you to write VisionOS with full support for platform SDK. This is a full fork of the main repository with changes needed to support VisionOS.
+React Native Vision OS allows you to write visionOS with full support for platform SDK. This is a full fork of the main repository with changes needed to support visionOS.
 
 This project is still at an early stage of development and is not ready for production use.
 
 ## Contributing
 
 1. Download latest Xcode beta [here](https://developer.apple.com/xcode/).
-2. Install VisionOS Simulator runtime. 
+2. Install visionOS Simulator runtime. 
 3. Follow the same steps as for running iOS defined in [packages/rn-tester/README.md](./packages/rn-tester/README.md)

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -201,7 +201,7 @@ type Props = $ReadOnly<{|
    */
   'aria-label'?: ?string,
   /**
-   * Props needed for VisionOS.
+   * Props needed for visionOS.
    */
   ...VisionOSProps,
 |}>;

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.d.ts
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.d.ts
@@ -88,7 +88,7 @@ export interface TouchableOpacityProps
   tvParallaxProperties?: TVParallaxProperties | undefined;
 
   /**
-   * Hover style to apply to the view. Only supported on VisionOS.
+   * Hover style to apply to the view. Only supported on visionOS.
    */
   visionos_hoverEffect?: HoverEffect | undefined;
 }

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -125,7 +125,7 @@ export interface ViewPropsIOS extends TVViewPropsIOS {
    */
   shouldRasterizeIOS?: boolean | undefined;
   /**
-   * Hover style to apply to the view. Only supported on VisionOS.
+   * Hover style to apply to the view. Only supported on visionOS.
    */
   visionos_hoverEffect?: HoverEffect | undefined;
 }

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -440,7 +440,7 @@ type IOSViewProps = $ReadOnly<{|
   shouldRasterizeIOS?: ?boolean,
 
   /**
-   * Hover style to apply to the view. Only supported on VisionOS.
+   * Hover style to apply to the view. Only supported on visionOS.
    */
   visionos_hoverEffect?: ?HoverEffect,
 |}>;

--- a/packages/react-native/React/Views/RCTViewManager.h
+++ b/packages/react-native/React/Views/RCTViewManager.h
@@ -81,7 +81,7 @@ typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNu
 
 #if TARGET_OS_VISION
 /**
- * These macros allow properties to only be mapped in VisionOS.
+ * These macros allow properties to only be mapped in visionOS.
  */
 #define RCT_EXPORT_NOT_VISIONOS_VIEW_PROPERTY(name, type)
 #define RCT_EXPORT_VISIONOS_VIEW_PROPERTY(name, type) \


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR renames VisionOS to visionOS so it matches official OS name (https://developer.apple.com/documentation/visionos)
