### PR TITLE
chore: remove not necessary ifs `TARGET_OS_VISION`, minimise code diff

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -96,7 +96,7 @@ RCT_ENUM_CONVERTER(
 
 @end
 #else
-@interface RCTPushNotificationManager ()
+@interface RCTPushNotificationManager () <NativePushNotificationManagerIOSSpec>
 @end
 #endif // TARGET_OS_UIKITFORMAC
 

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -89,14 +89,14 @@ static BOOL RCTIsIPhoneNotched()
 {
   static BOOL isIPhoneNotched = NO;
 #if !TARGET_OS_VISION
-    static dispatch_once_t onceToken;
+  static dispatch_once_t onceToken;
 
-    dispatch_once(&onceToken, ^{
-      RCTAssertMainQueue();
+  dispatch_once(&onceToken, ^{
+    RCTAssertMainQueue();
 
-      // 20pt is the top safeArea value in non-notched devices
-      isIPhoneNotched = RCTSharedApplication().keyWindow.safeAreaInsets.top > 20;
-    });
+  // 20pt is the top safeArea value in non-notched devices
+  isIPhoneNotched = RCTSharedApplication().keyWindow.safeAreaInsets.top > 20;
+});
 #endif
   return isIPhoneNotched;
 }

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (NSString *)withAnima
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RCTSharedApplication() setStatusBarHidden:hidden withAnimation:animation];
+  [RCTSharedApplication() setStatusBarHidden:hidden withAnimation:animation];
 #pragma clang diagnostic pop
     }
   });
@@ -172,7 +172,9 @@ RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (NSString *)withAnima
 RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 {
 #if !TARGET_OS_VISION
-    RCTSharedApplication().networkActivityIndicatorVisible = visible;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      RCTSharedApplication().networkActivityIndicatorVisible = visible;
+    });
 #endif
 }
 

--- a/packages/react-native/React/Views/RCTWrapperViewController.m
+++ b/packages/react-native/React/Views/RCTWrapperViewController.m
@@ -29,9 +29,6 @@
 
   if ((self = [super initWithNibName:nil bundle:nil])) {
     _contentView = contentView;
-#if !TARGET_OS_VISION
-    self.automaticallyAdjustsScrollViewInsets = NO;
-#endif
   }
   return self;
 }

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.h
@@ -21,5 +21,3 @@
 @interface RCTScrollViewManager : RCTViewManager
 
 @end
-
-

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
@@ -12,8 +12,6 @@
 #import "RCTShadowView.h"
 #import "RCTUIManager.h"
 
-
-
 @implementation RCTConvert (UIScrollView)
 
 #if !TARGET_OS_VISION

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -12,7 +12,7 @@
 #import <ReactCommon/RCTSampleTurboModule.h>
 #import <ReactCommon/SampleTurboCxxModule.h>
 
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC && !TARGET_OS_VISION
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 #import <React/RCTPushNotificationManager.h>
 #endif
 
@@ -86,7 +86,7 @@ NSString *kBundlePath = @"js/RNTesterApp.ios";
   return nullptr;
 }
 
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC && !TARGET_OS_VISION
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 
 // Required for the remoteNotificationsRegistered event.
 - (void)application:(__unused UIApplication *)application
@@ -102,6 +102,7 @@ NSString *kBundlePath = @"js/RNTesterApp.ios";
   [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
+#if !TARGET_OS_VISION
 // Required for the remoteNotificationReceived event.
 - (void)application:(__unused UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
 {
@@ -114,6 +115,7 @@ NSString *kBundlePath = @"js/RNTesterApp.ios";
 {
   [RCTPushNotificationManager didReceiveLocalNotification:notification];
 }
+#endif
 
 #endif
 


### PR DESCRIPTION
## Summary:

This PR reduces code diff between visionos and core. It also removes some not needed checks. 

## Changelog:


[INTERNAL] [REMOVED] - Remove not needed TARGET_OS_VISION ifs 



## Test Plan:

Check if the app runs.
