### PR TITLE
fix: remove keyboard listerners and mark as unsupported

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -114,6 +114,13 @@ class Keyboard {
     );
 
   constructor() {
+    if (Platform.isVisionOS) {
+      console.warn(
+        'Keyboard is not supported on VisionOS. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
+      );
+      return;
+    }
+
     this.addListener('keyboardDidShow', ev => {
       this._currentlyShowing = ev;
     });
@@ -151,6 +158,10 @@ class Keyboard {
     listener: (...$ElementType<KeyboardEventDefinitions, K>) => mixed,
     context?: mixed,
   ): EventSubscription {
+    if (Platform.isVisionOS) {
+      return;
+    }
+
     return this._emitter.addListener(eventType, listener);
   }
 
@@ -160,6 +171,10 @@ class Keyboard {
    * @param {string} eventType The native event string listeners are watching which will be removed.
    */
   removeAllListeners<K: $Keys<KeyboardEventDefinitions>>(eventType: ?K): void {
+    if (Platform.isVisionOS) {
+      return;
+    }
+
     this._emitter.removeAllListeners(eventType);
   }
 

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -15,6 +15,7 @@ import LayoutAnimation from '../../LayoutAnimation/LayoutAnimation';
 import dismissKeyboard from '../../Utilities/dismissKeyboard';
 import Platform from '../../Utilities/Platform';
 import NativeKeyboardObserver from './NativeKeyboardObserver';
+import warnOnce from '../../Utilities/warnOnce';
 
 export type KeyboardEventName = $Keys<KeyboardEventDefinitions>;
 
@@ -115,8 +116,9 @@ class Keyboard {
 
   constructor() {
     if (Platform.isVisionOS) {
-      console.warn(
-        'Keyboard is not supported on VisionOS. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
+      warnOnce(
+        'Keyboard-unavailable',
+        'Keyboard is not available on visionOS platform. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
       );
       return;
     }

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -176,6 +176,12 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   componentDidMount(): void {
     if (Platform.OS === 'ios') {
+      if (Platform.isVisionOS) {
+        console.warn(
+          'KeyboardAvoidingView is not supported on VisionOS. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
+        );
+        return;
+      }
       this._subscriptions = [
         Keyboard.addListener('keyboardWillChangeFrame', this._onKeyboardChange),
       ];
@@ -205,6 +211,16 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       onLayout,
       ...props
     } = this.props;
+
+    if (Platform.isVisionOS) {
+      // KeyboardAvoidingView is not supported on VisionOS, so we return a simple View without the onLayout handler
+      return (
+        <View ref={this.viewRef} style={style} {...props}>
+          {children}
+        </View>
+      );
+    }
+
     const bottomHeight = enabled === true ? this.state.bottom : 0;
     switch (behavior) {
       case 'height':

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -24,6 +24,7 @@ import AccessibilityInfo from '../AccessibilityInfo/AccessibilityInfo';
 import View from '../View/View';
 import Keyboard from './Keyboard';
 import * as React from 'react';
+import warnOnce from '../../Utilities/warnOnce';
 
 type Props = $ReadOnly<{|
   ...ViewProps,
@@ -177,8 +178,9 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   componentDidMount(): void {
     if (Platform.OS === 'ios') {
       if (Platform.isVisionOS) {
-        console.warn(
-          'KeyboardAvoidingView is not supported on VisionOS. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
+        warnOnce(
+          'KeyboardAvoidingView-unavailable',
+          'KeyboardAvoidingView is not available on visionOS platform. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
         );
         return;
       }

--- a/packages/react-native/React/CoreModules/RCTKeyboardObserver.mm
+++ b/packages/react-native/React/CoreModules/RCTKeyboardObserver.mm
@@ -23,6 +23,7 @@ RCT_EXPORT_MODULE()
 
 - (void)startObserving
 {
+#if !TARGET_OS_VISION
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
 #define ADD_KEYBOARD_HANDLER(NAME, SELECTOR) [nc addObserver:self selector:@selector(SELECTOR:) name:NAME object:nil]
@@ -35,6 +36,7 @@ RCT_EXPORT_MODULE()
   ADD_KEYBOARD_HANDLER(UIKeyboardDidChangeFrameNotification, keyboardDidChangeFrame);
 
 #undef ADD_KEYBOARD_HANDLER
+#endif
 }
 
 - (NSArray<NSString *> *)supportedEvents
@@ -51,9 +53,12 @@ RCT_EXPORT_MODULE()
 
 - (void)stopObserving
 {
+#if !TARGET_OS_VISION
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+#endif
 }
 
+#if !TARGET_OS_VISION
 // Bridge might be already invalidated by the time the keyboard is about to be dismissed.
 // This might happen, for example, when reload from the packager is performed.
 // Thus we need to check against nil here.
@@ -72,6 +77,7 @@ IMPLEMENT_KEYBOARD_HANDLER(keyboardWillHide)
 IMPLEMENT_KEYBOARD_HANDLER(keyboardDidHide)
 IMPLEMENT_KEYBOARD_HANDLER(keyboardWillChangeFrame)
 IMPLEMENT_KEYBOARD_HANDLER(keyboardDidChangeFrame)
+#endif
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #6 

Mark `Keyboard.js` and `KeyboardAvoidingView.js` as unsupported and remove listeners in `RCTKeyboardObserver.mm`, because VisionOS displays the keyboard in a separate window, leaving the app window unaffected.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[VISIONOS] [ADDED] - warning about unavailable Keyboard
[VISIONOS] [ADDED] - warning about unavailable KeyboardAvoidingView
[VISIONOS] [CHANGED] - early return when adding and removing listeners in Keyboard
[VISIONOS] [CHANGED] - return passthrough View when rendering KeyboardAvoidingView on VisionOS
[VISIONOS] [CHANGED] - do nothing if TARGET_OS_VISION in `startObserving` and `stopObserving`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Open KeyboardAvoidingView in RNTester
2. Verify warn is displayed in the app and in the Metro logs
3. Verify examples should still load and function correctly