### PR TITLE
feat: support building visionOS with dynamic frameworks enabled

### DIFF
--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-  s.framework              = ["Accelerate", "UIKit"]
+  s.framework              = ["Accelerate", "UIKit", "QuartzCore", "ImageIO", "CoreGraphics"]
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -44,6 +44,8 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
 
+  s.framework = "UIKit"
+  
   s.dependency "React-Core/RCTLinkingHeaders", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -43,6 +43,8 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(" ")
                              }
 
+  s.framework = ["UIKit", "QuartzCore"]
+  
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"
   s.dependency "React-jsi"

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-  s.framework              = "UserNotifications"
+  s.framework              = ["UIKit", "UserNotifications"]
 
   s.dependency "RCTTypeSafety"
   s.dependency "React-Core/RCTPushNotificationHeaders"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -47,6 +47,8 @@ Pod::Spec.new do |s|
                                "USE_HEADERMAP" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "GCC_WARN_PEDANTIC" => "YES" }
+  s.framework = "UIKit"
+
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = './'
   end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -48,6 +48,8 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../../.."
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
+  
+  s.framework = "UIKit"
 
   s.pod_target_xcconfig  = { "USE_HEADERMAP" => "NO",
                              "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),

--- a/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
+++ b/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
 
+  s.framework = ["UIKit", "CoreGraphics"]
   # s.dependency "..."
 
   # Enable codegen for this library


### PR DESCRIPTION
## Summary:

This PR brings support for building visionOS with `use_frameworks! :linkage => dynamic`.

By default RN builds static libraries however, Xcode does not support building static libraries that include Swift code which is a major blocker for us (as we want to include Swift). 

## Changelog:

[VISIONOS] [FIXED] - Support building the app with dynamic `use_frameworks`

## Test Plan:

Check if RNTester is building with `use_frameworks`
