### PR TITLE
fix: ci on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,19 +53,17 @@ jobs:
           command: yarn install
       - when:
           condition:
-            and:
-              - equal: [ "https://github.com/facebook/react-native", << pipeline.project.git_url >> ]
-              - or:
-                - equal: [ main, << pipeline.git.branch >> ]
-                - matches:
-                    pattern: /0\.[0-9]+[\.[0-9]+]?-stable/
-                    value: << pipeline.git.branch >>
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches:
+                  pattern: /0\.[0-9]+[\.[0-9]+]?-stable/
+                  value: << pipeline.git.branch >>
           steps:
             - run:
                 name: "[Main or Stable] Create input fo config to test everything"
                 command: |
                   mkdir -p /tmp/circleci/
-                  echo '{ "run_all": true }' > /tmp/circleci/pipeline_config.json
+                  node ./scripts/circleci/pipeline_selection.js filter-jobs
       - when:
           condition:
             not:


### PR DESCRIPTION
This PR executes the `pipeline_selection.js` script also on main to filter out unnecessary pipelines. 