### PR TITLE
Fix build step for `@callstack/out-of-tree-platforms` 

### DIFF
--- a/.circleci/verdaccio.yml
+++ b/.circleci/verdaccio.yml
@@ -24,6 +24,10 @@ packages:
   '@react-native/*':
     access: $all
     publish: $all
+    proxy: npmjs
+  '@callstack/*':
+    access: $all
+    publish: $all
   '@*/*':
     access: $all
     publish: $authenticated

--- a/packages/out-of-tree-platforms/.gitignore
+++ b/packages/out-of-tree-platforms/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+/dist

--- a/packages/out-of-tree-platforms/index.js.flow
+++ b/packages/out-of-tree-platforms/index.js.flow
@@ -1,0 +1,1 @@
+export * from './src';

--- a/packages/out-of-tree-platforms/package.json
+++ b/packages/out-of-tree-platforms/package.json
@@ -8,17 +8,11 @@
     "url": "https://github.com/callstack/react-native-visionos.git",
     "directory": "packages/out-of-tree-platforms"
   },
+  "files": ["dist"],
   "homepage": "https://github.com/callstack/react-native-visionos/tree/HEAD/packages/out-of-tree-platforms#readme",
-  "keywords": [
-    "out-of-tree",
-    "react-native"
-  ],
-  "bugs": "https://github.com/facebook/react-native/issues",
-  "engines": {
-    "node": ">=18"
-  },
-  "exports": "./index.js",
-  "devDependencies": {
-    "metro-resolver": "^0.80.0"
-  }
+  "keywords": ["out-of-tree", "react-native"],
+  "bugs": "https://github.com/callstack/react-native-visionos/issues",
+  "engines": { "node": ">=18" },
+  "exports": { ".": "./dist/index.js", "./package.json": "./package.json" },
+  "devDependencies": { "metro-resolver": "^0.80.0" }
 }

--- a/packages/out-of-tree-platforms/src/index.js
+++ b/packages/out-of-tree-platforms/src/index.js
@@ -18,7 +18,7 @@ type ResolverConfig = {
  * Creates a custom Metro resolver that maps platform extensions to package names.
  * To be used in app's `metro.config.js` as `resolver.resolveRequest`.
  */
-const getPlatformResolver = (config: ResolverConfig): CustomResolver => {
+export const getPlatformResolver = (config: ResolverConfig): CustomResolver => {
   return (context, moduleName, platform) => {
     // `customResolverOptions` is populated through `?resolver.platformExtension` query params
     // in the jsBundleURLForBundleRoot method of the react-native/React/Base/RCTBundleURLProvider.mm
@@ -42,5 +42,3 @@ const getPlatformResolver = (config: ResolverConfig): CustomResolver => {
     return context.resolveRequest(context, modifiedModuleName, platform);
   };
 };
-
-module.exports = {getPlatformResolver};

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -45,6 +45,10 @@ const buildConfig /*: BuildConfig */ = {
     'community-cli-plugin': {
       target: 'node',
     },
+    'out-of-tree-platforms': {
+      target: 'node',
+      emitTypeScriptDefs: true,
+    },
     'dev-middleware': {
       target: 'node',
       emitTypeScriptDefs: true,

--- a/scripts/oot-release.js
+++ b/scripts/oot-release.js
@@ -9,10 +9,13 @@
 const forEachPackage = require('./monorepo/for-each-package');
 const {applyPackageVersions, publishPackage} = require('./npm-utils');
 const updateTemplatePackage = require('./update-template-package');
+const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const {cat, echo, exit} = require('shelljs');
 const yargs = require('yargs');
+
+const REPO_ROOT = path.resolve(__dirname, '../');
 
 /**
  * This script updates core packages to the version of React Native that we are basing on,
@@ -115,6 +118,12 @@ function releaseOOT(
     ...visionOSPackages.reduce((acc, pkg) => ({...acc, [pkg]: newVersion}), {}),
   });
   echo(`Updating template and it's dependencies to ${reactNativeVersion}`);
+
+  echo('Building packages...\n');
+  execSync('node ./scripts/build/build.js', {
+    cwd: REPO_ROOT,
+    stdio: [process.stdin, process.stdout, process.stderr],
+  });
 
   // Release visionOS packages only if OTP is passed
   if (!oneTimePassword) {


### PR DESCRIPTION


## Summary:

This PR allows to properly build and release `@callstack/out-of-tree-platforms`  package emitting typescript and flow types. It also adds build step to our `oot-release.js` script

## Changelog:

[INTERNAL] [FIXED] - Fix build step for `@callstack/out-of-tree-platforms` 

## Test Plan:

Do a test release on verdaccio
