### PR TITLE
task(StatusBar component): show warn when using StatusBar

### DIFF
--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -394,6 +394,13 @@ class StatusBar extends React.Component<Props> {
   _stackEntry = null;
 
   componentDidMount() {
+    if (Platform.isVisionOS) {
+      warnOnce(
+        'StatusBar-unavailable',
+        'StatusBar is not available on visionOS platform.',
+      );
+      return;
+    }
     // Every time a StatusBar component is mounted, we push it's prop to a stack
     // and always update the native status bar with the props from the top of then
     // stack. This allows having multiple StatusBar components and the one that is
@@ -418,14 +425,6 @@ class StatusBar extends React.Component<Props> {
    * Updates the native status bar with the props from the stack.
    */
   static _updatePropsStack = () => {
-    if (Platform.isVisionOS) {
-      warnOnce(
-        'StatusBar-unavailable',
-        'StatusBar is not available on visionOS platform.',
-      );
-      return;
-    }
-
     // Send the update to the native module only once at the end of the frame.
     clearImmediate(StatusBar._updateImmediate);
     StatusBar._updateImmediate = setImmediate(() => {

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -12,6 +12,7 @@ import type {ColorValue} from '../../StyleSheet/StyleSheet';
 
 import processColor from '../../StyleSheet/processColor';
 import Platform from '../../Utilities/Platform';
+import warnOnce from '../../Utilities/warnOnce';
 import NativeStatusBarManagerAndroid from './NativeStatusBarManagerAndroid';
 import NativeStatusBarManagerIOS from './NativeStatusBarManagerIOS';
 import invariant from 'invariant';
@@ -417,6 +418,14 @@ class StatusBar extends React.Component<Props> {
    * Updates the native status bar with the props from the stack.
    */
   static _updatePropsStack = () => {
+    if (Platform.isVisionOS) {
+      warnOnce(
+        'StatusBar-unavailable',
+        'StatusBar is not available on visionOS platform.',
+      );
+      return;
+    }
+
     // Send the update to the native module only once at the end of the frame.
     clearImmediate(StatusBar._updateImmediate);
     StatusBar._updateImmediate = setImmediate(() => {

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -91,7 +91,9 @@ RCT_EXPORT_MODULE()
 
 - (void)stopObserving
 {
+#if !TARGET_OS_VISION
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+#endif
 }
 
 - (void)emitEvent:(NSString *)eventName forNotification:(NSNotification *)notification


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

[Issue](https://github.com/callstack/react-native-visionos/issues/9)
Mark StatusBar as unsupported given VisionOS doesn't have a concept of StatusBar.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[VISIONOS] [ADDED] - warning about unavailable StatusBar
[VISIONOS] [CHANGED] - do nothing if TARGET_OS_VISION in stopObserving

## Test Plan:

1. Open StatusBar in RNTester
2. Verify warn is displayed in the app and in the Metro logs