### PR TITLE
fix(#48) local build of `@callstack/out-of-tree-platforms`

### DIFF
--- a/packages/out-of-tree-platforms/package.json
+++ b/packages/out-of-tree-platforms/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "exports": { 
-    ".": "./dist/index.js",
+    ".": "./src/index.js",
     "./package.json": "./package.json" 
   },
   "files": [

--- a/packages/out-of-tree-platforms/src/getPlatformResolver.js
+++ b/packages/out-of-tree-platforms/src/getPlatformResolver.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {CustomResolver} from 'metro-resolver';
+
+type ResolverConfig = {
+  platformNameMap: {[platform: string]: string},
+};
+
+/**
+ * Creates a custom Metro resolver that maps platform extensions to package names.
+ * To be used in app's `metro.config.js` as `resolver.resolveRequest`.
+ */
+export const getPlatformResolver = (config: ResolverConfig): CustomResolver => {
+  return (context, moduleName, platform) => {
+    // `customResolverOptions` is populated through `?resolver.platformExtension` query params
+    // in the jsBundleURLForBundleRoot method of the react-native/React/Base/RCTBundleURLProvider.mm
+    const platformExtension = context.customResolverOptions?.platformExtension;
+    let modifiedModuleName = moduleName;
+    if (
+      typeof platformExtension === 'string' &&
+      config.platformNameMap?.[platformExtension]
+    ) {
+      const packageName = config.platformNameMap[platformExtension];
+      if (moduleName === 'react-native') {
+        modifiedModuleName = packageName;
+      } else if (moduleName.startsWith('react-native/')) {
+        modifiedModuleName = `${packageName}/${modifiedModuleName.slice(
+          'react-native/'.length,
+        )}`;
+      }
+    }
+
+    return context.resolveRequest(context, modifiedModuleName, platform);
+  };
+};

--- a/packages/out-of-tree-platforms/src/index.js
+++ b/packages/out-of-tree-platforms/src/index.js
@@ -1,44 +1,5 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- * @format
- */
+if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
+  require('../../../scripts/build/babel-register').registerForMonorepo();
+}
 
-import type {CustomResolver} from 'metro-resolver';
-
-type ResolverConfig = {
-  platformNameMap: {[platform: string]: string},
-};
-
-/**
- * Creates a custom Metro resolver that maps platform extensions to package names.
- * To be used in app's `metro.config.js` as `resolver.resolveRequest`.
- */
-export const getPlatformResolver = (config: ResolverConfig): CustomResolver => {
-  return (context, moduleName, platform) => {
-    // `customResolverOptions` is populated through `?resolver.platformExtension` query params
-    // in the jsBundleURLForBundleRoot method of the react-native/React/Base/RCTBundleURLProvider.mm
-    const platformExtension = context.customResolverOptions?.platformExtension;
-    let modifiedModuleName = moduleName;
-
-    if (
-      typeof platformExtension === 'string' &&
-      config.platformNameMap?.[platformExtension]
-    ) {
-      const packageName = config.platformNameMap[platformExtension];
-      if (moduleName === 'react-native') {
-        modifiedModuleName = packageName;
-      } else if (moduleName.startsWith('react-native/')) {
-        modifiedModuleName = `${packageName}/${modifiedModuleName.slice(
-          'react-native/'.length,
-        )}`;
-      }
-    }
-
-    return context.resolveRequest(context, modifiedModuleName, platform);
-  };
-};
+export * from './getPlatformResolver';

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
-    "nullthrows": "^1.1.1"
+    "nullthrows": "^1.1.1",
+    "@callstack/out-of-tree-platforms": "0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR should fix issues with running local RNTester app while packages are not built. For some reason RN core is not running a `postinstall` script that builds the packages so `@callstack/out-of-tree-platforms` wasn't built after cloning the repo. 

## Changelog:

[INTERNAL] [FIXED] - fix: local build of RNTester with `@callstack/out-of-tree-platforms`

## Test Plan:

CI Green
