### PR TITLE
feat: add error about CMake 3.28.0 being required

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermesc-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermesc-xcode.sh
@@ -9,6 +9,21 @@ set -x -e
 hermesc_dir_path="$1"; shift
 jsi_path="$1"
 
+
+# VisionOS support has been added to CMake from version 3.28.0 onwards. Error out if the version is lower.
+function check_cmake_version {
+  required_version="3.28.0"
+  cmake_version=$($CMAKE_BINARY --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+
+  if ! printf "%s\n%s\n" "$required_version" "$cmake_version" | sort -V | head -n 1 | grep -q "$required_version"; then
+    echo "error: CMake version $required_version or higher is required. Found: $cmake_version"
+    exit 1
+  fi
+}
+
+check_cmake_version
+
+
 # This script is supposed to be executed from Xcode "run script" phase.
 # Xcode sets up its build environment based on the build target (iphone, iphonesimulator, macodsx).
 # We want to make sure that hermesc is built for mac.


### PR DESCRIPTION
## Summary:

This PR adds error to Hermes build phase that we need at least CMake 3.28.0 to build visionOS.


![CleanShot 2023-12-20 at 13 30 37@2x](https://github.com/callstack/react-native-visionos/assets/52801365/f6f82d52-9442-4edd-baa5-409fd1c54b7c)


## Changelog:

[VISIONOS] [ADDED] - Error out on CMake 3.28.0 being required

## Test Plan:

Build Hermes with unsupported version of CMake
