### PR TITLE
feat: implement visionos cli commands

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -23,8 +23,8 @@
   ],
   "dependencies": {
     "@react-native/dev-middleware": "0.74.0",
-    "@react-native-community/cli-server-api": "13.0.0",
-    "@react-native-community/cli-tools": "13.0.0",
+    "@react-native-community/cli-server-api": "13.5.0",
+    "@react-native-community/cli-tools": "13.5.0",
     "@react-native/metro-babel-transformer": "0.74.0",
     "chalk": "^4.0.0",
     "execa": "^5.1.1",

--- a/packages/react-native/local-cli/localCommands.js
+++ b/packages/react-native/local-cli/localCommands.js
@@ -1,0 +1,43 @@
+const {
+  buildOptions,
+  createBuild,
+  createLog,
+  createRun,
+  logOptions,
+  runOptions,
+} = require('@react-native-community/cli-platform-apple');
+
+const run = {
+  name: 'run-visionos',
+  description: 'builds your app and starts it on visionOS simulator',
+  func: createRun({platformName: 'visionos'}),
+  examples: [
+    {
+      desc: 'Run on a specific simulator',
+      cmd: 'npx @callstack/react-native-visionos run-visionos --simulator "Apple Vision Pro"',
+    },
+  ],
+  options: runOptions,
+};
+
+const log = {
+  name: 'log-visionos',
+  description: 'starts visionOS device syslog tail',
+  func: createLog({platformName: 'visionos'}),
+  options: logOptions,
+};
+
+const build = {
+  name: 'build-visionos',
+  description: 'builds your app for visionOS platform',
+  func: createBuild({platformName: 'visionos'}),
+  examples: [
+      {
+      desc: 'Build the app for all visionOS devices in Release mode',
+      cmd: 'npx @callstack/react-native-visionos build-visionos --mode "Release"',
+      },
+  ],
+  options: buildOptions,
+};
+
+module.exports = [run, log, build];

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -95,9 +95,10 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-community/cli": "13.0.0",
-    "@react-native-community/cli-platform-android": "13.0.0",
-    "@react-native-community/cli-platform-ios": "13.0.0",
+    "@react-native-community/cli": "13.5.0",
+    "@react-native-community/cli-platform-android": "13.5.0",
+    "@react-native-community/cli-platform-ios": "13.5.0",
+    "@react-native-community/cli-platform-apple": "13.5.0",
     "@react-native/assets-registry": "0.74.0",
     "@react-native/community-cli-plugin": "0.74.0",
     "@react-native/codegen": "0.74.0",

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -9,7 +9,12 @@
 
 'use strict';
 
+const localCommands = require('./local-cli/localCommands');
 const android = require('@react-native-community/cli-platform-android');
+const {
+  getDependencyConfig,
+  getProjectConfig,
+} = require('@react-native-community/cli-platform-apple');
 const ios = require('@react-native-community/cli-platform-ios');
 const {
   bundleCommand,
@@ -52,12 +57,13 @@ module.exports = {
     ramBundleCommand,
     startCommand,
     codegenCommand,
+    ...localCommands,
   ],
   platforms: {
     visionos: {
       npmPackageName: '@callstack/react-native-visionos',
-      projectConfig: ios.projectConfig,
-      dependencyConfig: ios.dependencyConfig,
+      projectConfig: getProjectConfig({platformName: 'visionos'}),
+      dependencyConfig: getDependencyConfig({platformName: 'visionos'}),
     },
     ios: {
       projectConfig: ios.projectConfig,

--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "visionos": "react-native run-visionos",
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,43 +2384,44 @@
   optionalDependencies:
     npmlog "2 || ^3.1.0 || ^4.0.0"
 
-"@react-native-community/cli-clean@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-13.0.0.tgz#5ac3b088f015965082bf3e286e2174c2595cc11a"
-  integrity sha512-ysOGB7Th2wuOnXuSdOZW/0eSlLCpyALHd7TpqKn11ykArfqrqzjwcjvO43MgiVG982DpYXbTMVt6ATEpLO65Ig==
+"@react-native-community/cli-clean@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-13.5.0.tgz#50525bd637251644b082d1aff7907474b3312899"
+  integrity sha512-68wYb7ICE0aBqaVxuDYO4wVupSGkkk52qru+uMKTYOUm0KyHoAX8Sa8FebO/LR40CxkpgKwbLsT4yDxDOp2g1Q==
   dependencies:
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-tools" "13.5.0"
     chalk "^4.1.2"
     execa "^5.0.0"
 
-"@react-native-community/cli-config@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-13.0.0.tgz#36607d480d3efa4a6c351b681626fd0ef41d6c91"
-  integrity sha512-u81kuajfbSp2gnDuM/YzE3zcdYFvDzIyL+wr/4hOGueCvSCP6ZhS0LxXMAezBx8hwjwutG+pPJG13tb371V6sQ==
+"@react-native-community/cli-config@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-13.5.0.tgz#2c12ba3d2842971825765acb734fe95bb0422b8a"
+  integrity sha512-THuIH5euLpDn+nRepu5xxdh8kqFKlduKxADWOxBzHNNPLX7PlNRWcEBihQHTkCcG642fup1fJQXwR9tLH69KkQ==
   dependencies:
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-tools" "13.5.0"
     chalk "^4.1.2"
     cosmiconfig "^5.1.0"
     deepmerge "^4.3.0"
     glob "^7.1.3"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.0.0.tgz#dd362c957e8db9a94fda7317bf3385f1ce82b8b3"
-  integrity sha512-SsvVrLZBwvd8tRCWvsZwj8Kzaf1mQFQ+BUfZzt+oOztGZFXLFQ8eN13IPUZBHeyfFUtI62jteotse1X9BalRUQ==
+"@react-native-community/cli-debugger-ui@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.5.0.tgz#8fa46651604c8f0ef7d5d6a896340a167d280c75"
+  integrity sha512-I1Rj9ECQ75ItgdePy4gaDw8/PslbMwOrFVKhEaSf1Uxe4UEU5zAwovLYB09lBCvz+dAVT609Jo99L4y6zycDgA==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-13.0.0.tgz#89da6fffc25c4b67c1e0d4753f2d69f2b510c8e1"
-  integrity sha512-IxYhuGIPcvCTiccVzjw3dgb3YPvdn3iKwCPY4YzL9TeR4DLB+S5f+bfcVqrAwJWgj9F9EAldLYsQGteR7RWBCA==
+"@react-native-community/cli-doctor@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-13.5.0.tgz#e35e19c7b7292e63e3766a1477017de35aa0f40f"
+  integrity sha512-VNiA/Fw3SDShzN1xibAS39EqaeEa07aQPHn7RcJ+Pgn+SthGD4tKQcTLaRed/KEfFumQ9Tu/aismXPGLzfUKfw==
   dependencies:
-    "@react-native-community/cli-config" "13.0.0"
-    "@react-native-community/cli-platform-android" "13.0.0"
-    "@react-native-community/cli-platform-ios" "13.0.0"
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-config" "13.5.0"
+    "@react-native-community/cli-platform-android" "13.5.0"
+    "@react-native-community/cli-platform-apple" "13.5.0"
+    "@react-native-community/cli-platform-ios" "13.5.0"
+    "@react-native-community/cli-tools" "13.5.0"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     deepmerge "^4.3.0"
@@ -2435,53 +2436,60 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-hermes@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-13.0.0.tgz#978e8304c95f4c0b2d31c9490b7f1d4e72e187e5"
-  integrity sha512-FN6Zs1fJ+CyR8war9QGxI+2dMeFbqmhR4W1n+XaBZA/QbNPR1kPD+zs87zalzSJuFlYoVyGaTHoVDJHGGpjKTQ==
+"@react-native-community/cli-hermes@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-13.5.0.tgz#b7bd71e1b2335097dd3e973d90acb3708297b4b8"
+  integrity sha512-wyvOg54DwO/1McWgIiVuN81qSPciPv2sgRkntB8sydkNINSjSEVXNwgl28uQyRY/CmMpMAclTzLSrlUOHFBmrQ==
   dependencies:
-    "@react-native-community/cli-platform-android" "13.0.0"
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-platform-android" "13.5.0"
+    "@react-native-community/cli-tools" "13.5.0"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
 
-"@react-native-community/cli-platform-android@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-13.0.0.tgz#9ea8d9cd959d58b1ff0404030b15a2068c6cfbad"
-  integrity sha512-qpd6eOTtzL4MnHOhwvU1pVSr+Q2d/gy27T77Fx0Cc98YWz2Uy/KqEQ4d2Zch+4gNhmSBmE6ewQa1XIF767vCPA==
+"@react-native-community/cli-platform-android@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-13.5.0.tgz#004dd433d55f54d400748597ed34823877944174"
+  integrity sha512-pMcV9B5D2CH7kOeI2BCVL37MSnA1ZozZ6ZXgnkmuu0w3blTuN4QUp1fWxIhlfOSysuIB0Mribj7S34Dz0eg8Mw==
   dependencies:
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-tools" "13.5.0"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-xml-parser "^4.2.4"
     glob "^7.1.3"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-ios@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.0.0.tgz#250d823174a7f3e6e46d03fabaf40c6f3c301e0b"
-  integrity sha512-x3fMunOlXbcw0zlRxwnvwSQMdQVnANqHlLDrd0neiLzf/dG094PqtCbyJSFmw+65+iViemnzfwGDmocrVPuiOA==
+"@react-native-community/cli-platform-apple@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.5.0.tgz#979ee99c8e1dc1059d0f1d35ced362e580aed3c7"
+  integrity sha512-I6NeL5pPxrgZEZmjemHL4fWK5Q4trMqWgCu0ffqK2XMC1OqiI5Iqj3nBHEGJU0xiv09KzzxfHy150yhOyOU+eA==
   dependencies:
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-tools" "13.5.0"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-xml-parser "^4.0.12"
     glob "^7.1.3"
     ora "^5.4.1"
 
-"@react-native-community/cli-plugin-metro@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-13.0.0.tgz#4c3bfcd8f51a8c5212355c4110d5f81c9783c8ea"
-  integrity sha512-HcIF23/Af5ghqV5F1ksHVIwVjVtHFeKht4U14DbO85HWw19SwYJ8O+GdDafXy7wdpxE6s0H4ZZDFnNk3zoc/Hg==
-
-"@react-native-community/cli-server-api@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-13.0.0.tgz#e937503c6fb3fa42e8380e2b35cb18f19e168c6d"
-  integrity sha512-PHg/dc4BQhMgV0LzrZ0JFus1hrYIOl2yOOb5SsHklQALhtQebAozEtMOJMmQ5G/yjRxKcfaLwTm+MoydC0fPlw==
+"@react-native-community/cli-platform-ios@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.5.0.tgz#c55ec19553d98bb2fda6901bbfc8adeffc2a92f8"
+  integrity sha512-Z1KdRPIJGRi/iwHW2k5B3FVCy+1BtTAz45oYfGbqdP51GJqmbo0za7DcNQSy0cgbord9DHMSucFxVhrJKeRgvA==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "13.0.0"
-    "@react-native-community/cli-tools" "13.0.0"
+    "@react-native-community/cli-platform-apple" "13.5.0"
+
+"@react-native-community/cli-plugin-metro@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-13.5.0.tgz#2d3d431885650000e377630a192f5daca4180b34"
+  integrity sha512-1SBV0xT47TuM6tRxPmR86Bz0RdffoGFnJcfChM1M+reUNmFz92yKWNJ8x3K3db5+2gWsrER7LET27eETqzsM2w==
+
+"@react-native-community/cli-server-api@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-13.5.0.tgz#5a862b4ff88ba97416548d0980c806eb7d44eb6c"
+  integrity sha512-B4LaShCnxhqm1klRFVEI/4evABhjPsCjwHAbDjFS4MZtnlS78kr249qSdwwDiU2GlezrKGNK5SN+mNZp1R5OYg==
+  dependencies:
+    "@react-native-community/cli-debugger-ui" "13.5.0"
+    "@react-native-community/cli-tools" "13.5.0"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
@@ -2490,10 +2498,10 @@
     serve-static "^1.13.1"
     ws "^7.5.1"
 
-"@react-native-community/cli-tools@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-13.0.0.tgz#c3136dc3648f763f3eb6068df56ca14f12ace155"
-  integrity sha512-3C/GiFpIJbbuWgH+4T63vmL7K1OjYIs62rbGJp+BW6BbCTZpgMMk3EMZz1fNctaNcj+95jqmnd01PYTE1s/sIA==
+"@react-native-community/cli-tools@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-13.5.0.tgz#4a2fa67d27f579dacc6bfb06591b368632e5fc00"
+  integrity sha512-p47uy8Cqkhrso1Fog6zzdQ5edyg224uOdzfjsjl9bzSj2UqerAJafgQBFEdovP5teOdwxNyTrlzPCPTLLjKFvA==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
@@ -2506,27 +2514,27 @@
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-types@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-13.0.0.tgz#319c40479cbaee256c032583674da2b0571ed81e"
-  integrity sha512-YkxUKej10MBwlgcFs1ltV5ofsKbsdPMjAluIhVzTfU+paIqATSdyvUVOw/7wCqujQnBdm0xJlLyjXQy9qzpJeQ==
+"@react-native-community/cli-types@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-13.5.0.tgz#1a0cca901c5c78f43ee8e3924271f1db7943e961"
+  integrity sha512-8Cij8eYqXJNZl1j2//0Q2pzqWH/qTRBUaznCu2D5EXY6cJfplUsM/y7hKcrTam7KMbREP4c9EoZsbOftJJbfHw==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-13.0.0.tgz#8c6b5337cc149b80c049b50ed3127862ff3357e7"
-  integrity sha512-keDK0pJDUhTqm0Wj7IibdeWecMmD/obUagf/eTC+pCmt5Pyqy/3S8mObKwvYUH1HZk6YHtFAgqF7qUMpBE05ww==
+"@react-native-community/cli@13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-13.5.0.tgz#072bb19af4ed0f02f4f1b7684954d75e5da16393"
+  integrity sha512-f4ljPmnNG98su/sAG/wN9cGGsHi037w4ShrripjVBJf9LvkXcWI9T99+n+uVHH/UYydRsfJnihi2bNBCXQ31Hg==
   dependencies:
-    "@react-native-community/cli-clean" "13.0.0"
-    "@react-native-community/cli-config" "13.0.0"
-    "@react-native-community/cli-debugger-ui" "13.0.0"
-    "@react-native-community/cli-doctor" "13.0.0"
-    "@react-native-community/cli-hermes" "13.0.0"
-    "@react-native-community/cli-plugin-metro" "13.0.0"
-    "@react-native-community/cli-server-api" "13.0.0"
-    "@react-native-community/cli-tools" "13.0.0"
-    "@react-native-community/cli-types" "13.0.0"
+    "@react-native-community/cli-clean" "13.5.0"
+    "@react-native-community/cli-config" "13.5.0"
+    "@react-native-community/cli-debugger-ui" "13.5.0"
+    "@react-native-community/cli-doctor" "13.5.0"
+    "@react-native-community/cli-hermes" "13.5.0"
+    "@react-native-community/cli-plugin-metro" "13.5.0"
+    "@react-native-community/cli-server-api" "13.5.0"
+    "@react-native-community/cli-tools" "13.5.0"
+    "@react-native-community/cli-types" "13.5.0"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"
@@ -7127,7 +7135,7 @@ metro-minify-terser@0.80.3:
   dependencies:
     terser "^5.15.0"
 
-metro-resolver@0.80.3, metro-resolver@^0.80.3:
+metro-resolver@0.80.3, metro-resolver@^0.80.0, metro-resolver@^0.80.3:
   version "0.80.3"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.80.3.tgz#f9676508583d81182c7afaabc908254dc928a345"
   integrity sha512-zwa0i32rj/TI3NivcvMXHJwTG2gUgo2dXdcnAJlhEKKQvyN+7AfhNdQSlDdDqMQmU7FaLRdeWORnQJbYCrprQQ==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR implements: `run-visionos`, `build-visionos` and `log-visionos` CLI commands.

This PR needs `cli-platform-apple` to be released

## Changelog:

[VISIONOS] [ADDED] - visionOS CLI commands

## Test Plan:

Test new CLI commands in initialized project
