### PR TITLE
remove: GlassViewController is no longer needed

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -49,21 +49,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 }
 @end
 
-#if TARGET_OS_VISION
-@interface GlassViewController : UIViewController
-
-@end
-
-@implementation GlassViewController
-
-- (UIContainerBackgroundStyle)preferredContainerBackgroundStyle {
-    return UIContainerBackgroundStyleGlass;
-}
-
-@end
-#endif
-
-
 static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabricEnabled)
 {
   NSMutableDictionary *mutableProps = [initialProps mutableCopy] ?: [NSMutableDictionary new];
@@ -180,11 +165,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (UIViewController *)createRootViewController
 {
-#if TARGET_OS_VISION
-  return [GlassViewController new];
-#else
   return [UIViewController new];
-#endif
 }
 
 - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController


### PR DESCRIPTION
## Summary:

This PR removes `GlassViewController` which is no longer needed, minimizing fork surface. Looks like in the latest Beta Glass appearance is set by default.

## Changelog:

[VISIONOS] [REMOVED] - `GlassViewController`

## Test Plan:

Check if the app has glass appearance