### PR TITLE
fix: don't warn users about the Keyboard API all the time

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -116,10 +116,6 @@ class Keyboard {
 
   constructor() {
     if (Platform.isVisionOS) {
-      warnOnce(
-        'Keyboard-unavailable',
-        'Keyboard is not available on visionOS platform. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
-      );
       return;
     }
 
@@ -161,6 +157,10 @@ class Keyboard {
     context?: mixed,
   ): EventSubscription {
     if (Platform.isVisionOS) {
+      warnOnce(
+        'Keyboard-unavailable',
+        'Keyboard API is not available on visionOS platform. The system displays the keyboard in a separate window, leaving the app’s window unaffected by the keyboard’s appearance and disappearance',
+      );
       return {remove() {}};
     }
 

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -764,22 +764,24 @@ class ScrollView extends React.Component<Props, State> {
     this._keyboardMetrics = Keyboard.metrics();
     this._additionalScrollOffset = 0;
 
-    this._subscriptionKeyboardWillShow = Keyboard.addListener(
-      'keyboardWillShow',
-      this.scrollResponderKeyboardWillShow,
-    );
-    this._subscriptionKeyboardWillHide = Keyboard.addListener(
-      'keyboardWillHide',
-      this.scrollResponderKeyboardWillHide,
-    );
-    this._subscriptionKeyboardDidShow = Keyboard.addListener(
-      'keyboardDidShow',
-      this.scrollResponderKeyboardDidShow,
-    );
-    this._subscriptionKeyboardDidHide = Keyboard.addListener(
-      'keyboardDidHide',
-      this.scrollResponderKeyboardDidHide,
-    );
+    if (Platform.isVisionOS) {
+      this._subscriptionKeyboardWillShow = Keyboard.addListener(
+        'keyboardWillShow',
+        this.scrollResponderKeyboardWillShow,
+      );
+      this._subscriptionKeyboardWillHide = Keyboard.addListener(
+        'keyboardWillHide',
+        this.scrollResponderKeyboardWillHide,
+      );
+      this._subscriptionKeyboardDidShow = Keyboard.addListener(
+        'keyboardDidShow',
+        this.scrollResponderKeyboardDidShow,
+      );
+      this._subscriptionKeyboardDidHide = Keyboard.addListener(
+        'keyboardDidHide',
+        this.scrollResponderKeyboardDidHide,
+      );
+    }
 
     this._updateAnimatedNodeAttachment();
   }


### PR DESCRIPTION
## Summary:

This PR moves the warnOnce to the addEventListener() method of KeyboardAPI. This avoids informing users multiple times about the keyboard API being unavailable. Also, I removed the usage of Keyboard API from ScrollView.js to avoid emitting this warning from our code. 

## Changelog:

[VISIONOS] [FIXED] - Don't warn users about the Keyboard API all the time

## Test Plan:

CI Green
