### PR TITLE
fix: release build bundle

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -144,6 +144,7 @@ fi
   --entry-file "$ENTRY_FILE" \
   --platform "$BUNDLE_PLATFORM" \
   --dev $DEV \
+  --custom-resolver-options "platformExtension=visionos" \
   --reset-cache \
   --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST" \

--- a/packages/react-native/template/visionos/HelloWorld.xcodeproj/project.pbxproj
+++ b/packages/react-native/template/visionos/HelloWorld.xcodeproj/project.pbxproj
@@ -263,7 +263,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/@callstack/react-native-visionos/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/@callstack/react-native-visionos/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary:

This PR fixes the release bundle that wasn't using the react-native-visionos JS source code + we didn't pass the custom resolver option. 

Closes: #73 

## Changelog:

[VISIONOS] [FIXED] - release bundle build 

## Test Plan:

CI Green, release bundle has hover effects
