### PR TITLE
fix: remove duplicated isVision key

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -65,10 +65,6 @@ const Platform: PlatformType = {
     return this.constants.isDisableAnimations ?? this.isTesting;
   },
   // $FlowFixMe[unsafe-getters-setters]
-  get isVision(): boolean {
-    return false;
-  },
-  // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean {
     // $FlowFixMe[object-this-reference]
     return this.constants.uiMode === 'tv';


### PR DESCRIPTION
## Summary:

This PR removes duplicated `isVision` key in Platform.android.js