### PR TITLE
fix: providing unsupported value to hoverStyle crashed the app

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -532,23 +532,26 @@ using namespace facebook::react;
 
 #if TARGET_OS_VISION
 - (void) updateHoverEffect:(NSString*)hoverEffect withCornerRadius:(CGFloat)cornerRadius {
-    if (hoverEffect == nil || [hoverEffect isEqualToString:@""]) {
-        self.hoverStyle = nil;
-        return;
-    }
-    
-    UIShape *shape = [UIShape rectShapeWithCornerRadius:cornerRadius];
-    id<UIHoverEffect> effect;
-    
-    if ([hoverEffect isEqualToString:@"lift"]) {
-        effect = [UIHoverLiftEffect effect];
-    } else if ([hoverEffect isEqualToString:@"highlight"]) {
-        effect = [UIHoverHighlightEffect effect];
-    }
-    
-    if (hoverEffect != nil) {
-        self.hoverStyle = [UIHoverStyle styleWithEffect:effect shape:shape];
-    }
+  if (hoverEffect == nil) {
+    self.hoverStyle = nil;
+    return;
+  }
+  
+  UIShape *shape = [UIShape rectShapeWithCornerRadius:cornerRadius];
+  id<UIHoverEffect> effect;
+  
+  if ([hoverEffect isEqualToString:@"lift"]) {
+    effect = [UIHoverLiftEffect effect];
+  } else if ([hoverEffect isEqualToString:@"highlight"]) {
+    effect = [UIHoverHighlightEffect effect];
+  }
+  
+  if (effect == nil) {
+    self.hoverStyle = nil;
+    return;
+  }
+  
+  self.hoverStyle = [UIHoverStyle styleWithEffect:effect shape:shape];
 }
 #endif
 

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -669,36 +669,39 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
 
 #if TARGET_OS_VISION
 - (void)setHoverEffect:(NSString *)hoverEffect {
-    _hoverEffect = hoverEffect;
+  _hoverEffect = hoverEffect;
+  
+  if (hoverEffect == nil) {
+    self.hoverStyle = nil;
+    return;
+  }
+  
+  CGFloat cornerRadius = 0.0;
+  RCTCornerRadii cornerRadii = [self cornerRadii];
+  
+  if (RCTCornerRadiiAreEqual(cornerRadii)) {
+    cornerRadius = cornerRadii.topLeft;
     
-    if (hoverEffect == nil) {
-        self.hoverStyle = nil;
-        return;
-    }
-    
-    CGFloat cornerRadius = 0.0;
-    RCTCornerRadii cornerRadii = [self cornerRadii];
-    
-    if (RCTCornerRadiiAreEqual(cornerRadii)) {
-      cornerRadius = cornerRadii.topLeft;
-
-    } else {
-      // TODO: Handle a case when corner radius is different for each corner.
-      cornerRadius = cornerRadii.topLeft;
-    }
-    
-    UIShape *shape = [UIShape rectShapeWithCornerRadius:cornerRadius];
-    id<UIHoverEffect> effect;
-    
-    if ([hoverEffect isEqualToString:@"lift"]) {
-        effect = [UIHoverLiftEffect effect];
-    } else if ([hoverEffect isEqualToString:@"highlight"]) {
-        effect = [UIHoverHighlightEffect effect];
-    }
-    
-    if (hoverEffect != nil) {
-        self.hoverStyle = [UIHoverStyle styleWithEffect:effect shape:shape];
-    }
+  } else {
+    // TODO: Handle a case when corner radius is different for each corner.
+    cornerRadius = cornerRadii.topLeft;
+  }
+  
+  UIShape *shape = [UIShape rectShapeWithCornerRadius:cornerRadius];
+  id<UIHoverEffect> effect;
+  
+  if ([hoverEffect isEqualToString:@"lift"]) {
+    effect = [UIHoverLiftEffect effect];
+  } else if ([hoverEffect isEqualToString:@"highlight"]) {
+    effect = [UIHoverHighlightEffect effect];
+  }
+  
+  if (effect == nil) {
+    self.hoverStyle = nil;
+    return;
+  }
+  
+  self.hoverStyle = [UIHoverStyle styleWithEffect:effect shape:shape];
 }
 #endif
 


### PR DESCRIPTION
## Summary:

This PR fixes an issue where providing an unsupported value like `visionos_hoverEffect="test"` crashed the app.

## Changelog:

[VISIONOS] [FIXED] - Prevent app crash with unsupported values for hoverEffect