### PR TITLE
refactor: remove unused RCTForegroundWindow

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -96,9 +96,6 @@ RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
 RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 
 #if TARGET_OS_VISION
-// Returns the current active UIWindow based on UIWindowScene
-RCT_EXTERN UIWindow *__nullable RCTForegroundWindow(void);
-
 // Returns UIStatusBarManager to get it's configuration info.
 RCT_EXTERN UIStatusBarManager *__nullable RCTUIStatusBarManager(void);
 #endif

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -592,13 +592,6 @@ UIWindow *__nullable RCTKeyWindow(void)
 }
 
 #if TARGET_OS_VISION
-UIWindow *__nullable RCTForegroundWindow(void)
-{
-    // React native only supports single scene apps.
-    NSSet *scenes = RCTSharedApplication().connectedScenes;
-    UIWindowScene *firstScene = [scenes anyObject];
-    return [[UIWindow alloc] initWithWindowScene:firstScene];
-}
 
 UIStatusBarManager *__nullable RCTUIStatusBarManager(void) {
     NSSet *connectedScenes = RCTSharedApplication().connectedScenes;

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -11,27 +11,26 @@
 
 RCTDimensions RCTGetDimensions(CGFloat fontScale)
 {
-#if TARGET_OS_VISION
-  CGSize screenSize = RCTForegroundWindow().bounds.size;
-#else
+#if !TARGET_OS_VISION
   UIScreen *mainScreen = UIScreen.mainScreen;
   CGSize screenSize = mainScreen.bounds.size;
 #endif
+  
   UIView *mainWindow = RCTKeyWindow();
+  CGFloat screenScale = [UITraitCollection currentTraitCollection].displayScale;
+  
+#if TARGET_OS_VISION
+  CGSize windowSize = mainWindow.bounds.size;
+  CGSize screenSize = mainWindow.bounds.size;
+#else
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
-  CGFloat scale;
-#if TARGET_OS_VISION
-    scale = [UITraitCollection currentTraitCollection].displayScale;
-#else
-    scale = mainScreen.scale;
 #endif
-
   RCTDimensions result;
   typeof(result.screen) dimsScreen = {
-      .width = screenSize.width, .height = screenSize.height, .scale = scale, .fontScale = fontScale};
+      .width = screenSize.width, .height = screenSize.height, .scale = screenScale, .fontScale = fontScale};
   typeof(result.window) dimsWindow = {
-      .width = windowSize.width, .height = windowSize.height, .scale = scale, .fontScale = fontScale};
+      .width = windowSize.width, .height = windowSize.height, .scale = screenScale, .fontScale = fontScale};
   result.screen = dimsScreen;
   result.window = dimsWindow;
 


### PR DESCRIPTION
## Summary:

This PR removes unused `RCTForegroundWindow`, this became obsolete after introducing SwiftUI as the root #77 