### PR TITLE
fix: properly retrieve window when clicking DevMenu action

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -409,9 +409,15 @@ RCT_EXPORT_METHOD(show)
 {
   return ^(__unused UIAlertAction *action) {
     if (item) {
+#if TARGET_OS_VISION
+      /// Execute this handler after the action sheet is dismissed to properly retrieve window when using SwiftUI entry point.
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0), dispatch_get_main_queue(), ^{
+        [item callHandler];
+      });
+#else
       [item callHandler];
+#endif
     }
-
     self->_actionSheet = nil;
   };
 }


### PR DESCRIPTION
## Summary:

This PR fixes the retrieval of RCTKeyWindow when clicking either "Show Perf Monitor" or "Configure bundler". For some reason, the window was nil when we were calling this method in between closing the Dev Menu. Adding 0ms timer executes this code later (next loop) and thanks to this the window is properly retrieved. 