### PR TITLE
chore: remove hover effect & add cursor: pointer

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -20,7 +20,6 @@ import type {
   AccessibilityState,
   AccessibilityValue,
 } from '../View/ViewAccessibility';
-import type {HoverEffect} from '../View/ViewPropTypes';
 
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
@@ -33,16 +32,10 @@ import useAndroidRippleForView, {
 import * as React from 'react';
 import {useMemo, useRef, useState} from 'react';
 
-const defaultHoverEffect: HoverEffect = 'highlight';
-
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 
 export type StateCallbackType = $ReadOnly<{|
   pressed: boolean,
-|}>;
-
-type VisionOSProps = $ReadOnly<{|
-  visionos_hoverEffect?: ?HoverEffect,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -243,7 +236,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
     style,
     testOnly_pressed,
     unstable_pressDelay,
-    visionos_hoverEffect = defaultHoverEffect,
     ...restProps
   } = props;
 
@@ -353,8 +345,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       {...eventHandlers}
       ref={mergedRef}
       style={typeof style === 'function' ? style({pressed}) : style}
-      collapsable={false}
-      visionos_hoverEffect={visionos_hoverEffect}>
+      collapsable={false}>
       {typeof children === 'function' ? children({pressed}) : children}
       {__DEV__ ? <PressabilityDebugView color="red" hitSlop={hitSlop} /> : null}
     </View>

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -24,6 +24,7 @@ import type {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {type RectOrSize} from '../../StyleSheet/Rect';
+import StyleSheet from '../../StyleSheet/StyleSheet';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import View from '../View/View';
 import useAndroidRippleForView, {
@@ -193,10 +194,6 @@ type Props = $ReadOnly<{|
    * https://github.com/facebook/react-native/issues/34424
    */
   'aria-label'?: ?string,
-  /**
-   * Props needed for visionOS.
-   */
-  ...VisionOSProps,
 |}>;
 
 /**
@@ -344,13 +341,22 @@ function Pressable(props: Props, forwardedRef): React.Node {
       {...restPropsWithDefaults}
       {...eventHandlers}
       ref={mergedRef}
-      style={typeof style === 'function' ? style({pressed}) : style}
+      style={[
+        styles.pressable,
+        typeof style === 'function' ? style({pressed}) : style,
+      ]}
       collapsable={false}>
       {typeof children === 'function' ? children({pressed}) : children}
       {__DEV__ ? <PressabilityDebugView color="red" hitSlop={hitSlop} /> : null}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  pressable: {
+    cursor: 'pointer',
+  },
+});
 
 function usePressState(forcePressed: boolean): [boolean, (boolean) => void] {
   const [pressed, setPressed] = useState(false);

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
@@ -31,7 +31,14 @@ exports[`<Pressable /> should render as expected: should deep render when mocked
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -68,7 +75,14 @@ exports[`<Pressable /> should render as expected: should deep render when not mo
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -117,7 +131,14 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -154,7 +175,14 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -207,7 +235,14 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -244,7 +279,14 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -299,7 +341,14 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -336,7 +385,14 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -399,7 +455,14 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -436,7 +499,14 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  visionos_hoverEffect="highlight"
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -36,7 +36,6 @@ type Props = $ReadOnly<{|
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...AndroidProps,
   ...IOSProps,
-  ...VisionOSProps,
 
   activeOpacity?: ?number,
   underlayColor?: ?ColorValue,
@@ -330,10 +329,13 @@ class TouchableHighlight extends React.Component<Props, State> {
         accessibilityElementsHidden={
           this.props['aria-hidden'] ?? this.props.accessibilityElementsHidden
         }
-        style={StyleSheet.compose(
-          this.props.style,
-          this.state.extraStyles?.underlay,
-        )}
+        style={[
+          styles.touchable,
+          StyleSheet.compose(
+            this.props.style,
+            this.state.extraStyles?.underlay,
+          ),
+        ]}
         onLayout={this.props.onLayout}
         hitSlop={this.props.hitSlop}
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
@@ -379,6 +381,12 @@ class TouchableHighlight extends React.Component<Props, State> {
     this.state.pressability.reset();
   }
 }
+
+const styles = StyleSheet.create({
+  touchable: {
+    cursor: 'pointer',
+  },
+});
 
 const Touchable: React.AbstractComponent<
   $ReadOnly<$Diff<Props, {|hostRef: React.Ref<typeof View>|}>>,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -9,7 +9,6 @@
  */
 
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
-import type {HoverEffect} from '../View/ViewPropTypes';
 import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 
 import View from '../../Components/View/View';
@@ -31,10 +30,6 @@ type AndroidProps = $ReadOnly<{|
 
 type IOSProps = $ReadOnly<{|
   hasTVPreferredFocus?: ?boolean,
-|}>;
-
-type VisionOSProps = $ReadOnly<{|
-  hoverEffect?: ?HoverEffect,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -347,7 +342,6 @@ class TouchableHighlight extends React.Component<Props, State> {
         nextFocusLeft={this.props.nextFocusLeft}
         nextFocusRight={this.props.nextFocusRight}
         nextFocusUp={this.props.nextFocusUp}
-        visionos_hoverEffect={this.props.hoverEffect}
         focusable={
           this.props.focusable !== false && this.props.onPress !== undefined
         }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.d.ts
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.d.ts
@@ -11,7 +11,7 @@ import type * as React from 'react';
 import {Constructor} from '../../../types/private/Utilities';
 import {TimerMixin} from '../../../types/private/TimerMixin';
 import {NativeMethods} from '../../../types/public/ReactNativeTypes';
-import {HoverEffect, TVParallaxProperties} from '../View/ViewPropTypes';
+import {TVParallaxProperties} from '../View/ViewPropTypes';
 import {TouchableMixin} from './Touchable';
 import {TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
 
@@ -86,11 +86,6 @@ export interface TouchableOpacityProps
    * @platform android
    */
   tvParallaxProperties?: TVParallaxProperties | undefined;
-
-  /**
-   * Hover style to apply to the view. Only supported on visionOS.
-   */
-  visionos_hoverEffect?: HoverEffect | undefined;
 }
 
 /**

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -18,6 +18,7 @@ import Pressability, {
 } from '../../Pressability/Pressability';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import flattenStyle from '../../StyleSheet/flattenStyle';
+import StyleSheet from '../../StyleSheet/StyleSheet';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
@@ -33,7 +34,6 @@ type TVProps = $ReadOnly<{|
 type Props = $ReadOnly<{|
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...TVProps,
-  ...VisionOSProps,
 
   activeOpacity?: ?number,
   style?: ?ViewStyleProp,
@@ -276,7 +276,7 @@ class TouchableOpacity extends React.Component<Props, State> {
         accessibilityElementsHidden={
           this.props['aria-hidden'] ?? this.props.accessibilityElementsHidden
         }
-        style={[this.props.style, {opacity: this.state.anim}]}
+        style={[styles.touchable, this.props.style, {opacity: this.state.anim}]}
         nativeID={this.props.id ?? this.props.nativeID}
         testID={this.props.testID}
         onLayout={this.props.onLayout}
@@ -323,6 +323,12 @@ class TouchableOpacity extends React.Component<Props, State> {
     this.state.pressability.reset();
   }
 }
+
+const styles = StyleSheet.create({
+  touchable: {
+    cursor: 'pointer',
+  },
+});
 
 const Touchable: React.AbstractComponent<
   Props,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -9,7 +9,6 @@
  */
 
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
-import type {HoverEffect} from '../View/ViewPropTypes';
 import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 
 import Animated from '../../Animated/Animated';
@@ -22,8 +21,6 @@ import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
-const defaultHoverEffect: HoverEffect = 'highlight';
-
 type TVProps = $ReadOnly<{|
   hasTVPreferredFocus?: ?boolean,
   nextFocusDown?: ?number,
@@ -31,10 +28,6 @@ type TVProps = $ReadOnly<{|
   nextFocusLeft?: ?number,
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
-|}>;
-
-type VisionOSProps = $ReadOnly<{|
-  visionos_hoverEffect?: ?HoverEffect,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -138,10 +131,6 @@ type State = $ReadOnly<{|
  *
  */
 class TouchableOpacity extends React.Component<Props, State> {
-  static defaultProps: {|visionos_hoverEffect: HoverEffect|} = {
-    visionos_hoverEffect: defaultHoverEffect,
-  };
-
   state: State = {
     anim: new Animated.Value(this._getChildStyleOpacityWithDefault()),
     pressability: new Pressability(this._createPressabilityConfig()),
@@ -298,7 +287,6 @@ class TouchableOpacity extends React.Component<Props, State> {
         nextFocusUp={this.props.nextFocusUp}
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
         hitSlop={this.props.hitSlop}
-        visionos_hoverEffect={this.props.visionos_hoverEffect}
         focusable={
           this.props.focusable !== false && this.props.onPress !== undefined
         }

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -19,7 +19,14 @@ exports[`TouchableHighlight renders correctly 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={Object {}}
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      Object {},
+    ]
+  }
 >
   <Text>
     Touchable
@@ -51,6 +58,14 @@ exports[`TouchableHighlight with disabled state should be disabled when disabled
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -80,6 +95,14 @@ exports[`TouchableHighlight with disabled state should be disabled when disabled
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -109,6 +132,14 @@ exports[`TouchableHighlight with disabled state should disable button when acces
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -139,6 +170,14 @@ exports[`TouchableHighlight with disabled state should keep accessibilityState w
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>
@@ -168,6 +207,14 @@ exports[`TouchableHighlight with disabled state should overwrite accessibilitySt
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "cursor": "pointer",
+      },
+      undefined,
+    ]
+  }
 >
   <View />
 </View>

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
@@ -31,10 +31,10 @@ exports[`TouchableOpacity renders correctly 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <Text>
     Touchable
@@ -73,10 +73,10 @@ exports[`TouchableOpacity renders in disabled state when a disabled prop is pass
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <Text>
     Touchable
@@ -115,10 +115,10 @@ exports[`TouchableOpacity renders in disabled state when a key disabled in acces
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <Text>
     Touchable

--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -144,6 +144,7 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   borderTopLeftRadius: true,
   borderTopRightRadius: true,
   borderTopStartRadius: true,
+  cursor: true,
   opacity: true,
   pointerEvents: true,
 

--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -103,9 +103,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
       }
     : {
         uiViewClassName: 'RCTView',
-        validAttributes: {
-          visionos_hoverEffect: true,
-        },
       };
 
 const ViewNativeComponent: HostComponent<Props> =

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -16,8 +16,6 @@ import {LayoutChangeEvent, PointerEvents} from '../../Types/CoreEventTypes';
 import {Touchable} from '../Touchable/Touchable';
 import {AccessibilityProps} from './ViewAccessibility';
 
-export type HoverEffect = 'lift' | 'highlight';
-
 export type TVParallaxProperties = {
   /**
    * If true, parallax effects are enabled.  Defaults to true.
@@ -124,10 +122,6 @@ export interface ViewPropsIOS extends TVViewPropsIOS {
    * Test and measure when using this property.
    */
   shouldRasterizeIOS?: boolean | undefined;
-  /**
-   * Hover style to apply to the view. Only supported on visionOS.
-   */
-  visionos_hoverEffect?: HoverEffect | undefined;
 }
 
 export interface ViewPropsAndroid {

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -263,8 +263,6 @@ type AndroidDrawableRipple = $ReadOnly<{|
   rippleRadius?: ?number,
 |}>;
 
-export type HoverEffect = 'lift' | 'highlight';
-
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
 
 type AndroidViewProps = $ReadOnly<{|
@@ -453,11 +451,6 @@ type IOSViewProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/view#shouldrasterizeios
    */
   shouldRasterizeIOS?: ?boolean,
-
-  /**
-   * Hover style to apply to the view. Only supported on visionOS.
-   */
-  visionos_hoverEffect?: ?HoverEffect,
 |}>;
 
 export type ViewProps = $ReadOnly<{|

--- a/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
+++ b/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
@@ -32,10 +32,10 @@ exports[`<Button /> should be disabled and it should set accessibilityState to d
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -99,10 +99,10 @@ exports[`<Button /> should be disabled when disabled is empty and accessibilityS
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -166,10 +166,10 @@ exports[`<Button /> should be disabled when disabled={true} and accessibilitySta
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -234,10 +234,10 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -297,10 +297,10 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -359,10 +359,10 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -422,10 +422,10 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -485,10 +485,10 @@ exports[`<Button /> should overwrite accessibilityState with value of disabled p
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={
@@ -552,10 +552,10 @@ exports[`<Button /> should render as expected 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
+      "cursor": "pointer",
       "opacity": 1,
     }
   }
-  visionos_hoverEffect="highlight"
 >
   <View
     style={

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -27,6 +27,8 @@ export type DimensionValue =
 type AnimatableNumericValue = number | Animated.AnimatedNode;
 type AnimatableStringValue = string | Animated.AnimatedNode;
 
+export type CursorValue = 'auto' | 'pointer';
+
 /**
  * Flex Prop Types
  * @see https://reactnative.dev/docs/flexbox
@@ -274,6 +276,7 @@ export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
    * Controls whether the View can be the target of touch events.
    */
   pointerEvents?: 'box-none' | 'none' | 'box-only' | 'auto' | undefined;
+  cursor?: CursorValue | undefined;
 }
 
 export type FontVariant =
@@ -403,4 +406,5 @@ export interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
   tintColor?: ColorValue | undefined;
   opacity?: AnimatableNumericValue | undefined;
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | undefined;
+  cursor?: CursorValue | undefined;
 }

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -34,6 +34,8 @@ export type EdgeInsetsValue = {
   bottom: number,
 };
 
+export type CursorValue = ?('auto' | 'pointer');
+
 export type DimensionValue = number | string | 'auto' | AnimatedNode | null;
 export type AnimatableNumericValue = number | AnimatedNode;
 
@@ -729,6 +731,7 @@ export type ____ViewStyle_InternalCore = $ReadOnly<{
   opacity?: AnimatableNumericValue,
   elevation?: number,
   pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only',
+  cursor?: CursorValue,
 }>;
 
 export type ____ViewStyle_Internal = $ReadOnly<{

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1813,9 +1813,6 @@ exports[`public API should not change unintentionally Libraries/Components/Press
 export type StateCallbackType = $ReadOnly<{|
   pressed: boolean,
 |}>;
-type VisionOSProps = $ReadOnly<{|
-  visionos_hoverEffect?: ?HoverEffect,
-|}>;
 type Props = $ReadOnly<{|
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   accessibilityElementsHidden?: ?boolean,
@@ -1866,7 +1863,6 @@ type Props = $ReadOnly<{|
   testOnly_pressed?: ?boolean,
   unstable_pressDelay?: ?number,
   \\"aria-label\\"?: ?string,
-  ...VisionOSProps,
 |}>;
 declare export default React.AbstractComponent<
   Props,
@@ -3327,14 +3323,10 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
 type IOSProps = $ReadOnly<{|
   hasTVPreferredFocus?: ?boolean,
 |}>;
-type VisionOSProps = $ReadOnly<{|
-  hoverEffect?: ?HoverEffect,
-|}>;
 type Props = $ReadOnly<{|
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...AndroidProps,
   ...IOSProps,
-  ...VisionOSProps,
   activeOpacity?: ?number,
   underlayColor?: ?ColorValue,
   style?: ?ViewStyleProp,
@@ -3360,13 +3352,9 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
 |}>;
-type VisionOSProps = $ReadOnly<{|
-  visionos_hoverEffect?: ?HoverEffect,
-|}>;
 type Props = $ReadOnly<{|
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...TVProps,
-  ...VisionOSProps,
   activeOpacity?: ?number,
   style?: ?ViewStyleProp,
   hostRef?: ?React.Ref<typeof Animated.View>,
@@ -3665,7 +3653,6 @@ type AndroidDrawableRipple = $ReadOnly<{|
   borderless?: ?boolean,
   rippleRadius?: ?number,
 |}>;
-export type HoverEffect = \\"lift\\" | \\"highlight\\";
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
 type AndroidViewProps = $ReadOnly<{|
   accessibilityLabelledBy?: ?string | ?Array<string>,
@@ -3693,7 +3680,6 @@ type IOSViewProps = $ReadOnly<{|
   accessibilityElementsHidden?: ?boolean,
   accessibilityLanguage?: ?Stringish,
   shouldRasterizeIOS?: ?boolean,
-  visionos_hoverEffect?: ?HoverEffect,
 |}>;
 export type ViewProps = $ReadOnly<{|
   ...DirectEventProps,
@@ -7439,6 +7425,7 @@ export type EdgeInsetsValue = {
   right: number,
   bottom: number,
 };
+export type CursorValue = ?(\\"auto\\" | \\"pointer\\");
 export type DimensionValue = number | string | \\"auto\\" | AnimatedNode | null;
 export type AnimatableNumericValue = number | AnimatedNode;
 type ____LayoutStyle_Internal = $ReadOnly<{
@@ -7591,6 +7578,7 @@ export type ____ViewStyle_InternalCore = $ReadOnly<{
   opacity?: AnimatableNumericValue,
   elevation?: number,
   pointerEvents?: \\"auto\\" | \\"none\\" | \\"box-none\\" | \\"box-only\\",
+  cursor?: CursorValue,
 }>;
 export type ____ViewStyle_Internal = $ReadOnly<{
   ...____ViewStyle_InternalCore,

--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -11,6 +11,7 @@
 #import <React/RCTAnimationType.h>
 #import <React/RCTBorderCurve.h>
 #import <React/RCTBorderStyle.h>
+#import <React/RCTCursor.h>
 #import <React/RCTDefines.h>
 #import <React/RCTLog.h>
 #import <React/RCTPointerEvents.h>
@@ -79,6 +80,8 @@ typedef NSURL RCTFileURL;
 #if !TARGET_OS_TV
 + (UIBarStyle)UIBarStyle:(id)json __deprecated;
 #endif
+
++ (RCTCursor)RCTCursor:(id)json;
 
 + (CGFloat)CGFloat:(id)json;
 + (CGPoint)CGPoint:(id)json;

--- a/packages/react-native/React/Base/RCTConvert.m
+++ b/packages/react-native/React/Base/RCTConvert.m
@@ -549,6 +549,15 @@ RCT_ENUM_CONVERTER(
     UIBarStyleDefault,
     integerValue)
 
+RCT_ENUM_CONVERTER(
+    RCTCursor,
+    (@{
+      @"auto" : @(RCTCursorAuto),
+      @"pointer" : @(RCTCursorPointer),
+    }),
+    RCTCursorAuto,
+    integerValue)
+
 static void convertCGStruct(const char *type, NSArray *fields, CGFloat *result, id json)
 {
   NSUInteger count = fields.count;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -32,6 +32,7 @@ using namespace facebook::react;
   BOOL _needsInvalidateLayer;
   BOOL _isJSResponder;
   BOOL _removeClippedSubviews;
+  Cursor _cursor;
   NSMutableArray<UIView *> *_reactSubviews;
   NSSet<NSString *> *_Nullable _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 }
@@ -255,6 +256,12 @@ using namespace facebook::react;
   // `backfaceVisibility`
   if (oldViewProps.backfaceVisibility != newViewProps.backfaceVisibility) {
     self.layer.doubleSided = newViewProps.backfaceVisibility == BackfaceVisibility::Visible;
+  }
+  
+  // `cursor`
+  if (oldViewProps.cursor != newViewProps.cursor) {
+    _cursor = newViewProps.cursor;
+    needsInvalidateLayer = YES;
   }
 
   // `shouldRasterize`
@@ -590,6 +597,31 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     }
   } else {
     layer.shadowPath = nil;
+  }
+  
+  // Stage 1.5. Cursor / Hover Effects
+  if (@available(iOS 17.0, *)) {
+    UIHoverStyle *hoverStyle = nil;
+    if (_cursor == Cursor::Pointer) {
+      const RCTCornerInsets cornerInsets =
+          RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
+#if TARGET_OS_IOS
+      // Due to an Apple bug, it seems on iOS, UIShapes made with `[UIShape shapeWithBezierPath:]`
+      // evaluate their shape on the superviews' coordinate space. This leads to the hover shape
+      // rendering incorrectly on iOS, iOS apps in compatibility mode on visionOS, but not on visionOS.
+      // To work around this, for iOS, we can calculate the border path based on `view.frame` (the
+      // superview's coordinate space) instead of view.bounds.
+      CGPathRef borderPath = RCTPathCreateWithRoundedRect(self.frame, cornerInsets, NULL);
+#else // TARGET_OS_VISION
+      CGPathRef borderPath = RCTPathCreateWithRoundedRect(self.bounds, cornerInsets, NULL);
+#endif
+      UIBezierPath *bezierPath = [UIBezierPath bezierPathWithCGPath:borderPath];
+      CGPathRelease(borderPath);
+      UIShape *shape = [UIShape shapeWithBezierPath:bezierPath];
+      
+      hoverStyle = [UIHoverStyle styleWithEffect:[UIHoverAutomaticEffect effect] shape:shape];
+    }
+    [self setHoverStyle:hoverStyle];
   }
 
   // Stage 2. Border Rendering

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -296,24 +296,10 @@ using namespace facebook::react;
   }
 
   // `border`
-  if (oldViewProps.borderStyles != newViewProps.borderStyles ||
+  if (oldViewProps.borderStyles != newViewProps.borderStyles || oldViewProps.borderRadii != newViewProps.borderRadii ||
       oldViewProps.borderColors != newViewProps.borderColors) {
     needsInvalidateLayer = YES;
   }
-    // 'borderRadii'
-  if (oldViewProps.borderRadii != newViewProps.borderRadii) {
-    needsInvalidateLayer = YES;
-#if TARGET_OS_VISION
-    CGFloat borderRadius = newViewProps.borderRadii.all ? newViewProps.borderRadii.all.value() : 0.0;
-    [self updateHoverEffect:[NSString stringWithUTF8String:newViewProps.visionos_hoverEffect.c_str()] withCornerRadius:borderRadius];
-#endif
-    }
-#if TARGET_OS_VISION
-  if (oldViewProps.visionos_hoverEffect != newViewProps.visionos_hoverEffect) {
-    CGFloat borderRadius = newViewProps.borderRadii.all ? newViewProps.borderRadii.all.value() : 0.0;
-    [self updateHoverEffect:[NSString stringWithUTF8String:newViewProps.visionos_hoverEffect.c_str()] withCornerRadius:borderRadius];
-  }
-#endif
 
   // `nativeId`
   if (oldViewProps.nativeId != newViewProps.nativeId) {
@@ -527,31 +513,6 @@ using namespace facebook::react;
       return view != self ? view : nil;
   }
 }
-
-#if TARGET_OS_VISION
-- (void) updateHoverEffect:(NSString*)hoverEffect withCornerRadius:(CGFloat)cornerRadius {
-  if (hoverEffect == nil) {
-    self.hoverStyle = nil;
-    return;
-  }
-  
-  UIShape *shape = [UIShape rectShapeWithCornerRadius:cornerRadius];
-  id<UIHoverEffect> effect;
-  
-  if ([hoverEffect isEqualToString:@"lift"]) {
-    effect = [UIHoverLiftEffect effect];
-  } else if ([hoverEffect isEqualToString:@"highlight"]) {
-    effect = [UIHoverHighlightEffect effect];
-  }
-  
-  if (effect == nil) {
-    self.hoverStyle = nil;
-    return;
-  }
-  
-  self.hoverStyle = [UIHoverStyle styleWithEffect:effect shape:shape];
-}
-#endif
 
 static RCTCornerRadii RCTCornerRadiiFromBorderRadii(BorderRadii borderRadii)
 {

--- a/packages/react-native/React/Views/RCTCursor.h
+++ b/packages/react-native/React/Views/RCTCursor.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RCTCursor) {
+  RCTCursorAuto,
+  RCTCursorPointer,
+};
+

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -120,13 +120,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
  */
 @property (nonatomic, assign) UIEdgeInsets hitTestEdgeInsets;
 
-#if TARGET_OS_VISION
-/**
- *  The hover style to apply to a view, including an effect and a shape to use for displaying that effect.
- */
-@property (nonatomic, copy) NSString *hoverEffect;
-#endif
-
 /**
  * (Experimental and unused for Paper) Pointer event handlers.
  */

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -9,6 +9,7 @@
 
 #import <React/RCTBorderCurve.h>
 #import <React/RCTBorderStyle.h>
+#import <React/RCTCursor.h>
 #import <React/RCTComponent.h>
 #import <React/RCTPointerEvents.h>
 
@@ -119,6 +120,8 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
  *  Insets used when hit testing inside this view.
  */
 @property (nonatomic, assign) UIEdgeInsets hitTestEdgeInsets;
+
+@property (nonatomic, assign) RCTCursor cursor;
 
 /**
  * (Experimental and unused for Paper) Pointer event handlers.

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -136,6 +136,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     _borderCurve = RCTBorderCurveCircular;
     _borderStyle = RCTBorderStyleSolid;
     _hitTestEdgeInsets = UIEdgeInsetsZero;
+    _cursor = RCTCursorAuto;
 
     _backgroundColor = super.backgroundColor;
   }
@@ -796,6 +797,8 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
 
   RCTUpdateShadowPathForView(self);
 
+  RCTUpdateHoverStyleForView(self);
+
   const RCTCornerRadii cornerRadii = [self cornerRadii];
   const UIEdgeInsets borderInsets = [self bordersAsInsets];
   const RCTBorderColors borderColors = [self borderColorsWithTraitCollection:self.traitCollection];
@@ -888,6 +891,31 @@ static void RCTUpdateShadowPathForView(RCTView *view)
           view.reactTag,
           [view class]);
     }
+  }
+}
+
+static void RCTUpdateHoverStyleForView(RCTView *view)
+{
+  if (@available(iOS 17.0, *)) {
+    UIHoverStyle *hoverStyle = nil;
+    if ([view cursor] == RCTCursorPointer) {
+      const RCTCornerRadii cornerRadii = [view cornerRadii];
+      const RCTCornerInsets cornerInsets = RCTGetCornerInsets(cornerRadii, UIEdgeInsetsZero);
+#if TARGET_OS_IOS
+      // Due to an Apple bug, it seems on iOS, `[UIShape shapeWithBezierPath:]` needs to
+      // be calculated in the superviews' coordinate space (view.frame). This is not true
+      // on other platforms like visionOS.
+      CGPathRef borderPath = RCTPathCreateWithRoundedRect(view.frame, cornerInsets, NULL);
+#else // TARGET_OS_VISION
+      CGPathRef borderPath = RCTPathCreateWithRoundedRect(view.bounds, cornerInsets, NULL);
+#endif
+      UIBezierPath *bezierPath = [UIBezierPath bezierPathWithCGPath:borderPath];
+      CGPathRelease(borderPath);
+      UIShape *shape = [UIShape shapeWithBezierPath:bezierPath];
+      
+      hoverStyle = [UIHoverStyle styleWithEffect:[UIHoverHighlightEffect effect] shape:shape];
+    }
+    [view setHoverStyle:hoverStyle];
   }
 }
 

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -666,45 +666,6 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
   };
 }
 
-
-#if TARGET_OS_VISION
-- (void)setHoverEffect:(NSString *)hoverEffect {
-  _hoverEffect = hoverEffect;
-  
-  if (hoverEffect == nil) {
-    self.hoverStyle = nil;
-    return;
-  }
-  
-  CGFloat cornerRadius = 0.0;
-  RCTCornerRadii cornerRadii = [self cornerRadii];
-  
-  if (RCTCornerRadiiAreEqual(cornerRadii)) {
-    cornerRadius = cornerRadii.topLeft;
-    
-  } else {
-    // TODO: Handle a case when corner radius is different for each corner.
-    cornerRadius = cornerRadii.topLeft;
-  }
-  
-  UIShape *shape = [UIShape rectShapeWithCornerRadius:cornerRadius];
-  id<UIHoverEffect> effect;
-  
-  if ([hoverEffect isEqualToString:@"lift"]) {
-    effect = [UIHoverLiftEffect effect];
-  } else if ([hoverEffect isEqualToString:@"highlight"]) {
-    effect = [UIHoverHighlightEffect effect];
-  }
-  
-  if (effect == nil) {
-    self.hoverStyle = nil;
-    return;
-  }
-  
-  self.hoverStyle = [UIHoverStyle styleWithEffect:effect shape:shape];
-}
-#endif
-
 - (RCTCornerRadii)cornerRadii
 {
   const BOOL isRTL = _reactLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -13,6 +13,7 @@
 #import "RCTBridge.h"
 #import "RCTConvert+Transform.h"
 #import "RCTConvert.h"
+#import "RCTCursor.h"
 #import "RCTLog.h"
 #import "RCTShadowView.h"
 #import "RCTUIManager.h"
@@ -195,6 +196,7 @@ RCT_REMAP_VIEW_PROPERTY(testID, reactAccessibilityElement.accessibilityIdentifie
 
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
 RCT_REMAP_VIEW_PROPERTY(backfaceVisibility, layer.doubleSided, css_backface_visibility_t)
+RCT_EXPORT_VIEW_PROPERTY(cursor, RCTCursor)
 RCT_REMAP_VIEW_PROPERTY(opacity, alpha, CGFloat)
 RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
 RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -194,7 +194,6 @@ RCT_REMAP_VIEW_PROPERTY(onAccessibilityEscape, reactAccessibilityElement.onAcces
 RCT_REMAP_VIEW_PROPERTY(testID, reactAccessibilityElement.accessibilityIdentifier, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
-RCT_REMAP_VISIONOS_VIEW_PROPERTY(visionos_hoverEffect, hoverEffect, NSString)
 RCT_REMAP_VIEW_PROPERTY(backfaceVisibility, layer.doubleSided, css_backface_visibility_t)
 RCT_REMAP_VIEW_PROPERTY(opacity, alpha, CGFloat)
 RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -140,6 +140,15 @@ BaseViewProps::BaseViewProps(
                                                        "shadowRadius",
                                                        sourceProps.shadowRadius,
                                                        {})),
+      cursor(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.cursor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "cursor",
+                    sourceProps.cursor,
+                    {})),
       transform(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.transform
                                                  : convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -71,17 +71,6 @@ BaseViewProps::BaseViewProps(
                     "backgroundColor",
                     sourceProps.backgroundColor,
                     {})),
-#if TARGET_OS_VISION
-    visionos_hoverEffect(
-        CoreFeatures::enablePropIteratorSetter
-            ? sourceProps.visionos_hoverEffect
-            : convertRawProp(
-                  context,
-                  rawProps,
-                  "visionos_hoverEffect",
-                  sourceProps.visionos_hoverEffect,
-                  {})),
-#endif
       borderRadii(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.borderRadii
                                                  : convertRawProp(
@@ -292,9 +281,6 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews);
     RAW_SET_PROP_SWITCH_CASE_BASIC(experimental_layoutConformance);
-#if TARGET_OS_VISION
-    RAW_SET_PROP_SWITCH_CASE_BASIC(visionos_hoverEffect);
-#endif
     // events field
     VIEW_EVENT_CASE(PointerEnter);
     VIEW_EVENT_CASE(PointerEnterCapture);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -51,6 +51,8 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
   Size shadowOffset{0, -3};
   Float shadowOpacity{};
   Float shadowRadius{3};
+  
+  Cursor cursor{};
 
   // Transform
   Transform transform{};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -63,10 +63,6 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
   PointerEventsMode pointerEvents{};
   EdgeInsets hitSlop{};
   bool onLayout{};
-    
-#if TARGET_OS_VISION
-  std::string visionos_hoverEffect{};
-#endif
 
   ViewEvents events{};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -706,6 +706,28 @@ inline void fromRawValue(
 }
 
 inline void fromRawValue(
+    const PropsParserContext& context,
+    const RawValue& value,
+    Cursor& result) {
+  result = Cursor::Auto;
+  react_native_expect(value.hasType<std::string>());
+  if (!value.hasType<std::string>()) {
+    return;
+  }
+  auto stringValue = (std::string)value;
+  if (stringValue == "auto") {
+    result = Cursor::Auto;
+    return;
+  }
+  if (stringValue == "pointer") {
+    result = Cursor::Pointer;
+    return;
+  }
+  LOG(ERROR) << "Could not parse Cursor:" << stringValue;
+  react_native_expect(false);
+}
+
+inline void fromRawValue(
     const PropsParserContext& /*context*/,
     const RawValue& value,
     LayoutConformance& result) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -91,6 +91,8 @@ enum class BorderCurve : uint8_t { Circular, Continuous };
 
 enum class BorderStyle : uint8_t { Solid, Dotted, Dashed };
 
+enum class Cursor : uint8_t { Auto, Pointer };
+
 enum class LayoutConformance : uint8_t { Undefined, Classic, Strict };
 
 template <typename T>

--- a/packages/rn-tester/js/examples/Cursor/CursorExample.js
+++ b/packages/rn-tester/js/examples/Cursor/CursorExample.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const React = require('react');
+const {StyleSheet, View} = require('react-native');
+
+function CursorExampleAuto() {
+  return (
+    <View style={styles.row}>
+      <View style={styles.box} />
+      <View style={styles.circle} />
+      <View style={styles.halfcircle} />
+      <View style={[styles.box, styles.solid]} />
+      <View style={[styles.circle, styles.solid]} />
+      <View style={[styles.halfcircle, styles.solid]} />
+    </View>
+  );
+}
+
+function CursorExamplePointer() {
+  return (
+    <View style={styles.row}>
+      <View style={[styles.box, styles.pointer]} />
+      <View style={[styles.circle, styles.pointer]} />
+      <View style={[styles.halfcircle, styles.pointer]} />
+      <View style={[styles.box, styles.solid, styles.pointer]} />
+      <View style={[styles.circle, styles.solid, styles.pointer]} />
+      <View style={[styles.halfcircle, styles.solid, styles.pointer]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    width: 100,
+    height: 100,
+    borderWidth: 2,
+  },
+  circle: {
+    width: 100,
+    height: 100,
+    borderWidth: 2,
+    borderRadius: 50,
+  },
+  halfcircle: {
+    width: 100,
+    height: 100,
+    borderWidth: 2,
+    borderTopStartRadius: 50,
+    borderBottomStartRadius: 50,
+  },
+  solid: {
+    backgroundColor: 'blue',
+  },
+  pointer: {
+    cursor: 'pointer',
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+});
+
+exports.title = 'Cursor';
+exports.category = 'UI';
+exports.description =
+  'Demonstrates setting a cursor, which affects the appearance when a pointer is over the View.';
+exports.examples = [
+  {
+    title: 'Default',
+    description: "Cursor: 'auto' or no cursor set ",
+    render: CursorExampleAuto,
+  },
+  {
+    title: 'Pointer',
+    description: 'cursor: pointer',
+    render: CursorExamplePointer,
+  },
+];

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -200,6 +200,10 @@ const APIs: Array<RNTesterModuleInfo> = ([
     module: require('../examples/Crash/CrashExample'),
   },
   {
+    key: 'CursorExample',
+    module: require('../examples/Cursor/CursorExample'),
+  },
+  {
     key: 'DevSettings',
     module: require('../examples/DevSettings/DevSettingsExample'),
   },


### PR DESCRIPTION
This PR removes `visionos_hoverEffect` prop which is about to be replaced with `cursor: pointer` style.

Next steps involve cherry picking https://github.com/facebook/react-native/pull/43078