### PR TITLE
fix: use clearColor instead of systemBackgroundColor for visionOS

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -113,7 +113,11 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
                                                                    sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
     
     rootView = (RCTRootView *)surfaceHostingProxyRootView;
+#if TARGET_OS_VISION
+    rootView.backgroundColor = [UIColor clearColor];
+#else
     rootView.backgroundColor = [UIColor systemBackgroundColor];
+#endif
     [self customizeRootView:(RCTRootView *)rootView];
     return rootView;
   }


### PR DESCRIPTION
## Summary:

This PR changes the background color to clearColor for visionOS. This makes app background a little lighter: 


## Before (SwiftUI on the left)

![CleanShot 2024-02-29 at 09 38 07@2x](https://github.com/callstack/react-native-visionos/assets/52801365/a9e2214e-e5d6-4223-931d-6c2c9e471ab1)

## After

![CleanShot 2024-02-29 at 09 38 40@2x](https://github.com/callstack/react-native-visionos/assets/52801365/94d030d1-96ec-4f8b-8951-803ba9cdb6fd)

## Changelog:


[VISIONOS] [CHANGED] - use clearColor instead of systemBackgroundColor for visionOS

## Test Plan:

Check if app background is now lighter