### PR TITLE
fix: hermes xcode build scripts

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -16,10 +16,7 @@ function get_platform_copy_destination {
     if [[ $1 == "macosx" ]]; then
       echo "macosx"
       return
-    elif [[ $1 == "xros" ]]; then
-      echo "xros"
-      return
-    elif [[ $1 == "xrsimulator" ]]; then
+    elif [[ $1 == "xrsimulator" || $1 == "xros" ]]; then
       echo "xros"
       return
     fi
@@ -31,8 +28,10 @@ function get_deployment_target {
     if [[ $1 == "macosx" ]]; then
       echo ${MACOSX_DEPLOYMENT_TARGET}
       return
+    elif [[ $1 == "xrsimulator" || $1 == "xros" ]]; then
+      echo ${XROS_DEPLOYMENT_TARGET}
+      return
     fi
-    
     echo ${IPHONEOS_DEPLOYMENT_TARGET}
 }
 

--- a/packages/react-native/template/visionos/HelloWorld/AppDelegate.swift
+++ b/packages/react-native/template/visionos/HelloWorld/AppDelegate.swift
@@ -9,7 +9,7 @@ class AppDelegate: RCTAppDelegate {
   
   override func bundleURL() -> URL? {
 #if DEBUG
-    RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index")
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
 #else
     Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 #endif


### PR DESCRIPTION
## Summary:

This PR fixes Hermes build scripts + unnecessary optional check `?` form AppDelegate. (Mostly picks from 0.74.0-rc.0)
 

## Test Plan:

CI Green
