### PR TITLE
feat: allow to use WindowHandlingModifier outside of RCTMainWindow

### DIFF
--- a/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
+++ b/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
@@ -37,7 +37,7 @@ public struct RCTMainWindow: Scene {
 /**
  Handles data sharing between React Native and SwiftUI views.
  */
-struct WindowHandlingModifier: ViewModifier {
+public struct WindowHandlingModifier: ViewModifier {
   typealias UserInfoType = Dictionary<String, AnyHashable>
   
   @Environment(\.reactContext) private var reactContext
@@ -45,7 +45,9 @@ struct WindowHandlingModifier: ViewModifier {
   @Environment(\.dismissWindow) private var dismissWindow
   @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
   
-  func body(content: Content) -> some View {
+  public init() {}
+  
+  public func body(content: Content) -> some View {
     // Attach listeners only if app supports multiple windows
     if supportsMultipleWindows {
       content


### PR DESCRIPTION
## Summary:

This PR exposes `WindowHandlingModifier` in order to allow users to ditch `RCTMainWindow` and use custom setup (for example when they want to add ornaments on main window).

```swift
@main
struct RC07401VISIONOSApp: App {
  @UIApplicationDelegateAdaptor var delegate: AppDelegate
  
  var body: some Scene {
    WindowGroup {
      RCTRootViewRepresentable(moduleName: "RC07401VISIONOS", initialProps: nil)
        .modifier(WindowHandlingModifier())
        // Add ornaments 
    }
  }
}
```

Resolves #136 

## Changelog:

[VISIONOS] [ADDED] - Expose WindowHandlingModifier


## Test Plan:

CI Green
