### PR TITLE
fix: deep and universal links 

### DIFF
--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -24,4 +24,6 @@
     continueUserActivity:(nonnull NSUserActivity *)userActivity
       restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler;
 
++ (void)onOpenURL:(nonnull NSURL *)url NS_SWIFT_NAME(onOpenURL(url:));
+
 @end

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -15,6 +15,7 @@
 #import "RCTLinkingPlugins.h"
 
 static NSString *const kOpenURLNotification = @"RCTOpenURLNotification";
+static NSURL *initialURL = nil;
 
 static void postNotificationWithURL(NSURL *URL, id sender)
 {
@@ -79,6 +80,16 @@ RCT_EXPORT_MODULE()
     [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:self userInfo:payload];
   }
   return YES;
+}
+
+
++ (void)onOpenURL:(NSURL *)url
+{
+  if (initialURL == nil) {
+    initialURL = url;
+  } else {
+    postNotificationWithURL(url, self);
+  }
 }
 
 - (void)handleOpenURLNotification:(NSNotification *)notification
@@ -153,6 +164,7 @@ RCT_EXPORT_METHOD(canOpenURL
 
 RCT_EXPORT_METHOD(getInitialURL : (RCTPromiseResolveBlock)resolve reject : (__unused RCTPromiseRejectBlock)reject)
 {
+#if !TARGET_OS_VISION
   NSURL *initialURL = nil;
   if (self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
     initialURL = self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
@@ -163,6 +175,8 @@ RCT_EXPORT_METHOD(getInitialURL : (RCTPromiseResolveBlock)resolve reject : (__un
       initialURL = ((NSUserActivity *)userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"]).webpageURL;
     }
   }
+#endif
+  // React Native visionOS uses static property to retrieve initialURL.
   resolve(RCTNullIfNil(initialURL.absoluteString));
 }
 

--- a/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
+++ b/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
@@ -20,6 +20,7 @@ import SwiftUI
 public struct RCTMainWindow: Scene {
   var moduleName: String
   var initialProps: RCTRootViewRepresentable.InitialPropsType
+  var onOpenURLCallback: ((URL) -> ())?
   
   public init(moduleName: String, initialProps: RCTRootViewRepresentable.InitialPropsType = nil) {
     self.moduleName = moduleName
@@ -30,7 +31,18 @@ public struct RCTMainWindow: Scene {
     WindowGroup {
       RCTRootViewRepresentable(moduleName: moduleName, initialProps: initialProps)
         .modifier(WindowHandlingModifier())
+        .onOpenURL(perform: { url in
+          onOpenURLCallback?(url)
+        })
     }
+  }
+}
+
+extension RCTMainWindow {
+  public func onOpenURL(perform action: @escaping (URL) -> ()) -> some Scene {
+    var scene = self
+    scene.onOpenURLCallback = action
+    return scene
   }
 }
 

--- a/packages/rn-tester/RNTester-visionOS/App.swift
+++ b/packages/rn-tester/RNTester-visionOS/App.swift
@@ -11,6 +11,9 @@ struct RNTesterApp: App {
   
   var body: some Scene {
     RCTMainWindow(moduleName: "RNTesterApp")
+      .onOpenURL(perform: { url in
+        RCTLinkingManager.onOpenURL(url: url)
+      })
     
     RCTWindow(id: "SecondWindow", sceneData: reactContext.getSceneData(id: "SecondWindow"))
       .defaultSize(CGSize(width: 400, height: 700))

--- a/packages/rn-tester/RNTester-visionOS/Info.plist
+++ b/packages/rn-tester/RNTester-visionOS/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.reactjs.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>rntester</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR allows to use deeplinks/universal links in React Native visionOS apps. 

In order to use this feature, users need to add this modifier to their App.swift file: 

```swift
@main
struct RNTesterApp: App {
  @UIApplicationDelegateAdaptor var delegate: AppDelegate
  
  var body: some Scene {
    RCTMainWindow(moduleName: "RNTesterApp")
      .onOpenURL(perform: { url in
        RCTLinkingManager.onOpenURL(url: url)
      })
  }
}
```

A more in-depth documentation page will be created.

Thanks to @thiagobrez for investigating this one and helping me with the implementation and testing 🙏

## Changelog:

[VISIONOS] [ADDED] - Support for deep links / universal links

## Test Plan:

Check if deeplink is opening the app
