### PR TITLE
feat: implement window manager events

### DIFF
--- a/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
+++ b/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
@@ -21,6 +21,10 @@ public struct RCTMainWindow: Scene {
   var moduleName: String
   var initialProps: RCTRootViewRepresentable.InitialPropsType
   var onOpenURLCallback: ((URL) -> ())?
+  let windowId: String = "0"
+  
+  @Environment(\.scenePhase) private var scenePhase
+  
   
   public init(moduleName: String, initialProps: RCTRootViewRepresentable.InitialPropsType = nil) {
     self.moduleName = moduleName
@@ -31,11 +35,25 @@ public struct RCTMainWindow: Scene {
     WindowGroup {
       RCTRootViewRepresentable(moduleName: moduleName, initialProps: initialProps)
         .modifier(WindowHandlingModifier())
+        .onChange(of: scenePhase, { _, newValue in
+          postWindowStateNotification(windowId: windowId, state: newValue)
+        })
         .onOpenURL(perform: { url in
           onOpenURLCallback?(url)
         })
     }
   }
+}
+
+public func postWindowStateNotification(windowId: String, state: SwiftUI.ScenePhase) {
+  NotificationCenter.default.post(
+    name: NSNotification.Name(rawValue: "RCTWindowStateDidChange"),
+    object: nil,
+    userInfo: [
+      "windowId": windowId,
+      "state": "\(state)"
+    ]
+  )
 }
 
 extension RCTMainWindow {

--- a/packages/react-native/Libraries/SwiftExtensions/RCTWindow.swift
+++ b/packages/react-native/Libraries/SwiftExtensions/RCTWindow.swift
@@ -13,6 +13,8 @@ public struct RCTWindow : Scene {
   var id: String
   var sceneData: RCTSceneData?
   var moduleName: String
+  @Environment(\.scenePhase) private var scenePhase
+
   
   public init(id: String, moduleName: String, sceneData: RCTSceneData?) {
     self.id = id
@@ -25,6 +27,9 @@ public struct RCTWindow : Scene {
       Group {
         if let sceneData {
           RCTRootViewRepresentable(moduleName: moduleName, initialProps: sceneData.props)
+            .onChange(of: scenePhase) { _, newValue in
+              postWindowStateNotification(windowId: id, state: newValue)
+            }
         }
       }
       .onAppear {

--- a/packages/react-native/Libraries/WindowManager/RCTWindowManager.h
+++ b/packages/react-native/Libraries/WindowManager/RCTWindowManager.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RCTWindowManager : NSObject <RCTBridgeModule>
+@interface RCTWindowManager : RCTEventEmitter
 
 @end

--- a/packages/react-native/Libraries/WindowManager/WindowManager.d.ts
+++ b/packages/react-native/Libraries/WindowManager/WindowManager.d.ts
@@ -1,8 +1,18 @@
+import {NativeEventSubscription} from '../EventEmitter/RCTNativeAppEventEmitter';
+
+type WindowManagerEvents = 'windowStateDidChange';
+
+type WindowState = {
+  windowId: string;
+  state: 'active' | 'inactive' | 'background';
+};
+
 export interface WindowStatic {
   id: String;
   open (props?: Object): Promise<void>;
   update (props: Object): Promise<void>;
   close (): Promise<void>;
+  addEventListener (type: WindowManagerEvents, handler: (info: WindowState) => void): NativeEventSubscription;
 }
 
 export interface WindowManagerStatic {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8982,16 +8982,17 @@ declare export default typeof NativeWindowManager;
 `;
 
 exports[`public API should not change unintentionally Libraries/WindowManager/WindowManager.js 1`] = `
-"declare const WindowManager: {
-  getWindow: (id: string) => Window,
-  get supportsMultipleScenes(): boolean,
+"export type WindowStateValues = \\"inactive\\" | \\"background\\" | \\"active\\";
+type WindowManagerEventDefinitions = {
+  windowStateDidChange: [{ state: WindowStateValues, windowId: string }],
 };
-declare class Window {
-  id: string;
-  constructor(id: string): void;
-  open(props: ?Object): Promise<void>;
-  close(): Promise<void>;
-  update(props: ?Object): Promise<void>;
+declare class WindowManager {
+  static getWindow: $FlowFixMe;
+  static addEventListener<K: $Keys<WindowManagerEventDefinitions>>(
+    type: K,
+    handler: (...$ElementType<WindowManagerEventDefinitions, K>) => void
+  ): ?EventSubscription;
+  static get supportsMultipleScenes(): boolean;
 }
 declare module.exports: WindowManager;
 "

--- a/packages/react-native/src/private/specs/visionos_modules/NativeWindowManager.js
+++ b/packages/react-native/src/private/specs/visionos_modules/NativeWindowManager.js
@@ -19,6 +19,10 @@ export interface Spec extends TurboModule {
   // $FlowIgnore[unclear-type]
   +updateWindow: (windowId: string, userInfo: Object) => Promise<void>;
   +closeWindow: (windowId: string) => Promise<void>;
+
+  // RCTEventEmitter
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('WindowManager'): ?Spec);

--- a/packages/rn-tester/js/examples/XR/XRExample.js
+++ b/packages/rn-tester/js/examples/XR/XRExample.js
@@ -19,6 +19,17 @@ const secondWindow = WindowManager.getWindow('SecondWindow');
 const OpenXRSession = () => {
   const [isOpen, setIsOpen] = React.useState(false);
 
+  React.useEffect(() => {
+    const listener = WindowManager.addEventListener(
+      'windowStateDidChange',
+      data => {
+        console.log('Window state changed to:', data);
+      },
+    );
+    return () => {
+      listener?.remove();
+    };
+  }, []);
   const openXRSession = async () => {
     try {
       if (!WindowManager.supportsMultipleScenes) {


### PR DESCRIPTION
## Summary:

This PR implements window manager events, which solves #135. 

Users will be able to listen to window state changes: 

```tsx
  React.useEffect(() => { 
    const listener = WindowManager.addEventListener('windowStateDidChange', (data) => {
      console.log('Window state changed to:', data);
    });
    return () => {
      listener.remove();
    };
  }, []);
```

![CleanShot 2024-04-16 at 13 49 36@2x](https://github.com/callstack/react-native-visionos/assets/52801365/bcf1011b-8778-443e-be36-f203aeb256c6)

The main window always has the id: `0`

## Changelog:


[VISIONOS] [ADDED] - Implement window manager events

## Test Plan:

CI Green
