### PR TITLE
Prevent Keyboard API in ScrollView

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -783,7 +783,7 @@ class ScrollView extends React.Component<Props, State> {
     this._keyboardMetrics = Keyboard.metrics();
     this._additionalScrollOffset = 0;
 
-    if (Platform.isVision) {
+    if (!Platform.isVision) {
       this._subscriptionKeyboardWillShow = Keyboard.addListener(
         'keyboardWillShow',
         this.scrollResponderKeyboardWillShow,


### PR DESCRIPTION

## Summary:
Hi! I am hitting an issue where the keyboard warning keeps popping up no matter what I do and I tracked it down to ScrollView.js.

In https://github.com/callstack/react-native-visionos/pull/71/ it was mentioned that the keyboard api was to be avoided if in visionOS but I think it currently is doing the opposite. I've tested this proposed change in simulator/device and it seems to be good, but maybe I'm understanding this wrong so feel free to close this PR if not! Thanks!

Before:
<img width="1050" alt="Screenshot 2024-04-18 at 9 24 33 PM" src="https://github.com/callstack/react-native-visionos/assets/8985705/6e8c6aaf-5b25-4620-8b29-929e521f717b">


After:

<img width="956" alt="Screenshot 2024-04-18 at 9 25 00 PM" src="https://github.com/callstack/react-native-visionos/assets/8985705/6e24c597-7857-4fff-a87a-75235e08b747">

## Test Plan:

To test, add a ScrollView in any app and see that the api error happens. You'll need to make sure metro refreshes the app to see the error since the warn once is currently working as intended.