### PR TITLE
Revert "feat: implement window manager events (#142)"

### DIFF
--- a/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
+++ b/packages/react-native/Libraries/SwiftExtensions/RCTMainWindow.swift
@@ -21,10 +21,6 @@ public struct RCTMainWindow: Scene {
   var moduleName: String
   var initialProps: RCTRootViewRepresentable.InitialPropsType
   var onOpenURLCallback: ((URL) -> ())?
-  let windowId: String = "0"
-  
-  @Environment(\.scenePhase) private var scenePhase
-  
   
   public init(moduleName: String, initialProps: RCTRootViewRepresentable.InitialPropsType = nil) {
     self.moduleName = moduleName
@@ -35,25 +31,11 @@ public struct RCTMainWindow: Scene {
     WindowGroup {
       RCTRootViewRepresentable(moduleName: moduleName, initialProps: initialProps)
         .modifier(WindowHandlingModifier())
-        .onChange(of: scenePhase, { _, newValue in
-          postWindowStateNotification(windowId: windowId, state: newValue)
-        })
         .onOpenURL(perform: { url in
           onOpenURLCallback?(url)
         })
     }
   }
-}
-
-public func postWindowStateNotification(windowId: String, state: SwiftUI.ScenePhase) {
-  NotificationCenter.default.post(
-    name: NSNotification.Name(rawValue: "RCTWindowStateDidChange"),
-    object: nil,
-    userInfo: [
-      "windowId": windowId,
-      "state": "\(state)"
-    ]
-  )
 }
 
 extension RCTMainWindow {

--- a/packages/react-native/Libraries/SwiftExtensions/RCTWindow.swift
+++ b/packages/react-native/Libraries/SwiftExtensions/RCTWindow.swift
@@ -13,8 +13,6 @@ public struct RCTWindow : Scene {
   var id: String
   var sceneData: RCTSceneData?
   var moduleName: String
-  @Environment(\.scenePhase) private var scenePhase
-
   
   public init(id: String, moduleName: String, sceneData: RCTSceneData?) {
     self.id = id
@@ -27,9 +25,6 @@ public struct RCTWindow : Scene {
       Group {
         if let sceneData {
           RCTRootViewRepresentable(moduleName: moduleName, initialProps: sceneData.props)
-            .onChange(of: scenePhase) { _, newValue in
-              postWindowStateNotification(windowId: id, state: newValue)
-            }
         }
       }
       .onAppear {

--- a/packages/react-native/Libraries/WindowManager/RCTWindowManager.h
+++ b/packages/react-native/Libraries/WindowManager/RCTWindowManager.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
-#import <React/RCTEventEmitter.h>
 
-@interface RCTWindowManager : RCTEventEmitter
+@interface RCTWindowManager : NSObject <RCTBridgeModule>
 
 @end

--- a/packages/react-native/Libraries/WindowManager/RCTWindowManager.mm
+++ b/packages/react-native/Libraries/WindowManager/RCTWindowManager.mm
@@ -10,40 +10,13 @@
 static NSString *const RCTOpenWindow = @"RCTOpenWindow";
 static NSString *const RCTDismissWindow = @"RCTDismissWindow";
 static NSString *const RCTUpdateWindow = @"RCTUpdateWindow";
-static NSString *const RCTWindowStateDidChangeEvent = @"windowStateDidChange";
 
-static NSString *const RCTWindowStateDidChange = @"RCTWindowStateDidChange";
-
-@interface RCTWindowManager () <NativeWindowManagerSpec> {
-  BOOL _hasAnyListeners;
-}
+@interface RCTWindowManager () <NativeWindowManagerSpec>
 @end
 
 @implementation RCTWindowManager
 
 RCT_EXPORT_MODULE(WindowManager)
-
-- (void)initialize {
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleWindowStateChanges:)
-                                               name:RCTWindowStateDidChange
-                                             object:nil];
-}
-
-- (void)invalidate {
-  [super invalidate];
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
--(void)startObserving
-{
-  _hasAnyListeners = YES;
-}
-
-- (void)stopObserving
-{
-  _hasAnyListeners = NO;
-}
 
 RCT_EXPORT_METHOD(openWindow
                   : (NSString *)windowId userInfo
@@ -95,17 +68,6 @@ RCT_EXPORT_METHOD(updateWindow
   });
 }
 
-- (void) handleWindowStateChanges:(NSNotification *)notification {
-  
-  if (_hasAnyListeners) {
-   [self sendEventWithName:RCTWindowStateDidChangeEvent body:notification.userInfo];
-  }
-}
-
-- (NSArray<NSString *> *)supportedEvents {
-  return @[RCTWindowStateDidChangeEvent];
-}
-
 - (facebook::react::ModuleConstants<JS::NativeWindowManager::Constants::Builder>)constantsToExport {
   return [self getConstants];
 }
@@ -123,15 +85,6 @@ RCT_EXPORT_METHOD(updateWindow
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params {
   return std::make_shared<facebook::react::NativeWindowManagerSpecJSI>(params);
-}
-
-+ (BOOL)requiresMainQueueSetup {
-  return YES;
-}
-
-- (dispatch_queue_t)methodQueue
-{
-  return dispatch_get_main_queue();
 }
 
 @end

--- a/packages/react-native/Libraries/WindowManager/WindowManager.d.ts
+++ b/packages/react-native/Libraries/WindowManager/WindowManager.d.ts
@@ -1,18 +1,8 @@
-import {NativeEventSubscription} from '../EventEmitter/RCTNativeAppEventEmitter';
-
-type WindowManagerEvents = 'windowStateDidChange';
-
-type WindowState = {
-  windowId: string;
-  state: 'active' | 'inactive' | 'background';
-};
-
 export interface WindowStatic {
   id: String;
   open (props?: Object): Promise<void>;
   update (props: Object): Promise<void>;
   close (): Promise<void>;
-  addEventListener (type: WindowManagerEvents, handler: (info: WindowState) => void): NativeEventSubscription;
 }
 
 export interface WindowManagerStatic {

--- a/packages/react-native/Libraries/WindowManager/WindowManager.js
+++ b/packages/react-native/Libraries/WindowManager/WindowManager.js
@@ -1,50 +1,26 @@
 /**
  * @format
- * @flow strict-local
+ * @flow strict
  * @jsdoc
  */
 
-import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
-import Platform from '../Utilities/Platform';
-import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import NativeWindowManager from './NativeWindowManager';
 
-export type WindowStateValues = 'inactive' | 'background' | 'active';
-
-type WindowManagerEventDefinitions = {
-  windowStateDidChange: [{state: WindowStateValues, windowId: string}],
-};
-
-let emitter: ?NativeEventEmitter<WindowManagerEventDefinitions>;
-
-if (NativeWindowManager != null) {
-  emitter = new NativeEventEmitter<WindowManagerEventDefinitions>(
-    Platform.OS !== 'ios' ? null : NativeWindowManager,
-  );
-}
-
-class WindowManager {
-  static getWindow = function (id: string): Window {
+const WindowManager = {
+  getWindow: function (id: string): Window {
     return new Window(id);
-  };
-
-  static addEventListener<K: $Keys<WindowManagerEventDefinitions>>(
-    type: K,
-    handler: (...$ElementType<WindowManagerEventDefinitions, K>) => void,
-  ): ?EventSubscription {
-    return emitter?.addListener(type, handler);
-  }
+  },
 
   // $FlowIgnore[unsafe-getters-setters]
-  static get supportsMultipleScenes(): boolean {
+  get supportsMultipleScenes(): boolean {
     if (NativeWindowManager == null) {
       return false;
     }
 
     const nativeConstants = NativeWindowManager.getConstants();
     return nativeConstants.supportsMultipleScenes || false;
-  }
-}
+  },
+};
 
 class Window {
   id: string;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9035,17 +9035,16 @@ declare export default typeof NativeWindowManager;
 `;
 
 exports[`public API should not change unintentionally Libraries/WindowManager/WindowManager.js 1`] = `
-"export type WindowStateValues = \\"inactive\\" | \\"background\\" | \\"active\\";
-type WindowManagerEventDefinitions = {
-  windowStateDidChange: [{ state: WindowStateValues, windowId: string }],
+"declare const WindowManager: {
+  getWindow: (id: string) => Window,
+  get supportsMultipleScenes(): boolean,
 };
-declare class WindowManager {
-  static getWindow: $FlowFixMe;
-  static addEventListener<K: $Keys<WindowManagerEventDefinitions>>(
-    type: K,
-    handler: (...$ElementType<WindowManagerEventDefinitions, K>) => void
-  ): ?EventSubscription;
-  static get supportsMultipleScenes(): boolean;
+declare class Window {
+  id: string;
+  constructor(id: string): void;
+  open(props: ?Object): Promise<void>;
+  close(): Promise<void>;
+  update(props: ?Object): Promise<void>;
 }
 declare module.exports: WindowManager;
 "

--- a/packages/react-native/src/private/specs/visionos_modules/NativeWindowManager.js
+++ b/packages/react-native/src/private/specs/visionos_modules/NativeWindowManager.js
@@ -19,10 +19,6 @@ export interface Spec extends TurboModule {
   // $FlowIgnore[unclear-type]
   +updateWindow: (windowId: string, userInfo: Object) => Promise<void>;
   +closeWindow: (windowId: string) => Promise<void>;
-
-  // RCTEventEmitter
-  +addListener: (eventName: string) => void;
-  +removeListeners: (count: number) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('WindowManager'): ?Spec);

--- a/packages/rn-tester/js/examples/XR/XRExample.js
+++ b/packages/rn-tester/js/examples/XR/XRExample.js
@@ -19,17 +19,6 @@ const secondWindow = WindowManager.getWindow('SecondWindow');
 const OpenXRSession = () => {
   const [isOpen, setIsOpen] = React.useState(false);
 
-  React.useEffect(() => {
-    const listener = WindowManager.addEventListener(
-      'windowStateDidChange',
-      data => {
-        console.log('Window state changed to:', data);
-      },
-    );
-    return () => {
-      listener?.remove();
-    };
-  }, []);
   const openXRSession = async () => {
     try {
       if (!WindowManager.supportsMultipleScenes) {


### PR DESCRIPTION
This API was not useful because you can achieve the same thing with AppState (visionOS doesn't differentiate between focused windows as I thought it does). 

It never got released so I'm reverting the implementation. 