### PR TITLE
chore: remove automatic cursor pointer

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -24,7 +24,6 @@ import type {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {type RectOrSize} from '../../StyleSheet/Rect';
-import StyleSheet from '../../StyleSheet/StyleSheet';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import View from '../View/View';
 import useAndroidRippleForView, {
@@ -348,22 +347,13 @@ function Pressable(
       {...restPropsWithDefaults}
       {...eventHandlers}
       ref={mergedRef}
-      style={[
-        styles.pressable,
-        typeof style === 'function' ? style({pressed}) : style,
-      ]}
+      style={typeof style === 'function' ? style({pressed}) : style}
       collapsable={false}>
       {typeof children === 'function' ? children({pressed}) : children}
       {__DEV__ ? <PressabilityDebugView color="red" hitSlop={hitSlop} /> : null}
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  pressable: {
-    cursor: 'pointer',
-  },
-});
 
 function usePressState(forcePressed: boolean): [boolean, (boolean) => void] {
   const [pressed, setPressed] = useState(false);

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
@@ -31,14 +31,6 @@ exports[`<Pressable /> should render as expected: should deep render when mocked
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -75,14 +67,6 @@ exports[`<Pressable /> should render as expected: should deep render when not mo
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -119,14 +103,6 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -163,14 +139,6 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -207,14 +175,6 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -251,14 +211,6 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -295,14 +247,6 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -339,14 +283,6 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -383,14 +319,6 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -427,14 +355,6 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -329,13 +329,10 @@ class TouchableHighlight extends React.Component<Props, State> {
         accessibilityElementsHidden={
           this.props['aria-hidden'] ?? this.props.accessibilityElementsHidden
         }
-        style={[
-          styles.touchable,
-          StyleSheet.compose(
-            this.props.style,
-            this.state.extraStyles?.underlay,
-          ),
-        ]}
+        style={StyleSheet.compose(
+          this.props.style,
+          this.state.extraStyles?.underlay,
+        )}
         onLayout={this.props.onLayout}
         hitSlop={this.props.hitSlop}
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
@@ -383,12 +380,6 @@ class TouchableHighlight extends React.Component<Props, State> {
     this.state.pressability.reset();
   }
 }
-
-const styles = StyleSheet.create({
-  touchable: {
-    cursor: 'pointer',
-  },
-});
 
 const Touchable: React.AbstractComponent<
   $ReadOnly<$Diff<Props, {|+hostRef: mixed|}>>,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -18,7 +18,6 @@ import Pressability, {
 } from '../../Pressability/Pressability';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import flattenStyle from '../../StyleSheet/flattenStyle';
-import StyleSheet from '../../StyleSheet/StyleSheet';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
@@ -276,7 +275,7 @@ class TouchableOpacity extends React.Component<Props, State> {
         accessibilityElementsHidden={
           this.props['aria-hidden'] ?? this.props.accessibilityElementsHidden
         }
-        style={[styles.touchable, this.props.style, {opacity: this.state.anim}]}
+        style={[this.props.style, {opacity: this.state.anim}]}
         nativeID={this.props.id ?? this.props.nativeID}
         testID={this.props.testID}
         onLayout={this.props.onLayout}
@@ -326,12 +325,6 @@ class TouchableOpacity extends React.Component<Props, State> {
     this.state.anim.resetAnimation();
   }
 }
-
-const styles = StyleSheet.create({
-  touchable: {
-    cursor: 'pointer',
-  },
-});
 
 const Touchable: React.AbstractComponent<
   Props,

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -19,14 +19,7 @@ exports[`TouchableHighlight renders correctly 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      Object {},
-    ]
-  }
+  style={Object {}}
 >
   <Text>
     Touchable
@@ -58,14 +51,6 @@ exports[`TouchableHighlight with disabled state should be disabled when disabled
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -95,14 +80,6 @@ exports[`TouchableHighlight with disabled state should be disabled when disabled
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -132,14 +109,6 @@ exports[`TouchableHighlight with disabled state should disable button when acces
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -170,14 +139,6 @@ exports[`TouchableHighlight with disabled state should keep accessibilityState w
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>
@@ -207,14 +168,6 @@ exports[`TouchableHighlight with disabled state should overwrite accessibilitySt
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  style={
-    Array [
-      Object {
-        "cursor": "pointer",
-      },
-      undefined,
-    ]
-  }
 >
   <View />
 </View>

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
@@ -31,7 +31,6 @@ exports[`TouchableOpacity renders correctly 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -73,7 +72,6 @@ exports[`TouchableOpacity renders in disabled state when a disabled prop is pass
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -115,7 +113,6 @@ exports[`TouchableOpacity renders in disabled state when a key disabled in acces
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }

--- a/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
+++ b/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
@@ -32,7 +32,6 @@ exports[`<Button /> should be disabled and it should set accessibilityState to d
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -99,7 +98,6 @@ exports[`<Button /> should be disabled when disabled is empty and accessibilityS
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -166,7 +164,6 @@ exports[`<Button /> should be disabled when disabled={true} and accessibilitySta
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -234,7 +231,6 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -297,7 +293,6 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -359,7 +354,6 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -422,7 +416,6 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -485,7 +478,6 @@ exports[`<Button /> should overwrite accessibilityState with value of disabled p
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }
@@ -552,7 +544,6 @@ exports[`<Button /> should render as expected 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "cursor": "pointer",
       "opacity": 1,
     }
   }


### PR DESCRIPTION
## Summary:

This PR removes the automatic cursor pointer.

Cursor pointer should now be applied by users in Stylesheet.

### Reason

This feature has been upstreamed to React Native Core, originating from this repository. Current behavior of this prop upstream is **opt-in** not opt-out as visionOS was doing. 

If at some point in the future, we get closer to merging visionOS support inside of React Native core this feature is going to be dropped anyways.

## Changelog:

[IOS] [DEPRECATED] - Don't apply the cursor pointer automatically


## Test Plan:

CI Green