### PR TITLE
fix: Manually download VisionOS SDK in CI

### DIFF
--- a/.github/actions/test-visionos-rntester/action.yml
+++ b/.github/actions/test-visionos-rntester/action.yml
@@ -38,6 +38,14 @@ runs:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Setup xcode build cache
       uses: ./.github/actions/setup-xcode-build-cache
+    - name: Download visionOS SDK
+      run: |
+        # https://github.com/actions/runner-images/issues/10559
+        sudo xcodebuild -runFirstLaunch
+        sudo xcrun simctl list
+        sudo xcodebuild -downloadPlatform visionOS
+        sudo xcodebuild -runFirstLaunch
+      shell: bash
     - name: Install CocoaPods dependencies
       shell: bash
       run: |


### PR DESCRIPTION
## Summary:

MacOS-14 runners no longer have the VisionOS SDK pre-installed, so we must download it prior to building for VisionOS: https://github.com/actions/runner-images/issues/10559. We can use the same solution as React Native Test App: https://github.com/microsoft/react-native-test-app/pull/2258/files

## Changelog:

- Adds a step to the VisionOS test runner to download the VisionOS SDK before attempting to build with XCode 

Pick one each for the category and type tags:

[VISIONOS] [FIXED] 

## Test Plan:

- CI should pass after this change
